### PR TITLE
Fix issue #25. Restore `else` branch for code that should've been short-circuited.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
 		"ms-azuretools.vscode-docker",
 		"mikestead.dotenv",
 		"ryanluker.vscode-coverage-gutters",
-		"davidwang.ini-for-vscode"
+		"davidwang.ini-for-vscode",
+		"github.vscode-pull-request-github"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/hither/remotejobhandler.py
+++ b/hither/remotejobhandler.py
@@ -145,13 +145,12 @@ class RemoteJobHandler(BaseJobHandler):
         if remote_handler is None:
             if self._compute_resource_id is None: return
             ka.store_file(x.path, to=self._kachery)
-
-        # A remote handler *is* configured.
-        x_compute_resource_id = remote_handler._compute_resource_id
-        #  If we *are* the remote handler, we don't need to do anything.
-        if x_compute_resource_id == self._compute_resource_id: return
-
-        raise Exception('This case not yet supported (we need to transfer data from one compute resource to another)')
+        else:   # A remote handler is configured.
+            x_compute_resource_id = remote_handler._compute_resource_id
+            #  If we *are* the remote handler, we don't need to do anything.
+            if x_compute_resource_id == self._compute_resource_id:
+                return
+            raise Exception('This case not yet supported (we need to transfer data from one compute resource to another)')
         
     def _report_active(self):
         db = self._get_db(collection='active_job_handlers')


### PR DESCRIPTION
I believe this is the intended behavior--we can't very well check values on a remote handler if none is configured.

While I usually favor inverting `if` statements to reduce nesting (thank you [resharper](https://www.jetbrains.com/resharper/)), in this instance it seemed clearer with the `else` branch.