### PR TITLE
Rewrite database.py to serve as self-contained interface to Mongo store

### DIFF
--- a/hither/_Config.py
+++ b/hither/_Config.py
@@ -1,9 +1,12 @@
 from collections import deque
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Deque, Dict, Union
-from .jobcache import JobCache
+from typing import Any, Deque, Dict, Union, TYPE_CHECKING
 from ._basejobhandler import BaseJobHandler
+
+## Construction to avoid circular imports at runtime when we just need to fix a type reference
+if TYPE_CHECKING:
+    from .jobcache import JobCache
 
 class Inherit(Enum):
     INHERIT = ''
@@ -15,7 +18,7 @@ class Config:
     def __init__(self,
         container: Union[str, bool, Inherit, None]=Inherit.INHERIT,
         job_handler: Union[BaseJobHandler, Inherit]=Inherit.INHERIT,
-        job_cache: Union[JobCache, Inherit, None]=Inherit.INHERIT,
+        job_cache: Union['JobCache', Inherit, None]=Inherit.INHERIT,
         download_results: Union[bool, Inherit, None]=Inherit.INHERIT,
         job_timeout: Union[float, Inherit, None]=Inherit.INHERIT
     ):

--- a/hither/_enums.py
+++ b/hither/_enums.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Union, Callable, List, Type
+from typing import Any, Union, Callable, List, Type, Dict, Tuple
 
 # TODO: NOTE: We should be targeting Python 3.7+ for performance reasons when using typing
 # NOTE: This will also allow self-referential class type annotations without the ''s, IF
@@ -28,9 +28,89 @@ class JobStatus(Enum):
     def prerun_statuses(cls: Type['JobStatus']) -> List['JobStatus']:
         return [JobStatus.PENDING, JobStatus.QUEUED]
 
+    @classmethod
+    def local_statuses(cls: Type['JobStatus']) -> List['JobStatus']:
+        return [JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.FINISHED, JobStatus.ERROR]
+
 class HitherFileType(Enum):
     FILE = 'file'
     NUMPY = 'ndarray'
     SERIALIZED_FILE = 'hither_file'
     
-    
+class JobKeys:
+    CLIENT_CODE = 'client_code'
+    CODE = 'code'
+    COMPUTE_RESOURCE = 'compute_resource_id'
+    COMPUTE_RESOURCE_STATUS = 'compute_resource_status' # the Job's status on the remote resource.
+    CONTAINER = 'container'
+    DOWNLOAD_RESULTS = 'download_results'
+    EXCEPTION = 'exception'
+    FUNCTION = 'function'
+    FUNCTION_NAME = 'function_name'
+    FUNCTION_VERSION = 'function_version'
+    JOB_HASH = 'hash'
+    JOB_ID = 'job_id'
+    JOB_TIMEOUT = 'job_timeout'
+    LABEL = 'label'
+    # represents whether the job state was last changed by the compute resource (as opposed to
+    # by the local job handler)
+    LAST_MODIFIED_BY_COMPUTE_RESOURCE = 'last_modified_by_compute_resource'
+    NO_RESOLVE_INPUT_FILES = 'no_resolve_input_files'
+    RESULT = 'result'
+    RUNTIME_INFO = 'runtime_info'
+    SERIALIZATION = 'job_serialized'
+    STATUS = 'status'
+    WRAPPED_ARGS = 'kwargs' # TODO CHANGE ME ONCE ALL REFERENCES ARE CENTRALIZED
+
+    @staticmethod
+    def _verify_serialized_job(doc:Dict[str, any]) -> bool:
+        """Checks an input dictionary (expected to correspond to a Job serialized to MongoDB job
+        monitor bus) for a bare minimum of required keys to establish it is actually a Job object.
+
+        Arguments:
+            doc {Dict[str, any]} -- Dictionary of fields corresponding to a Hither Job.
+
+        Returns:
+            bool -- True if required fields are present; else False.
+        """
+        required_keys = [
+            JobKeys.LABEL,
+            JobKeys.CODE,
+            JobKeys.CONTAINER
+        ]
+        for x in required_keys:
+            if not x in doc: return False
+        return True
+
+    @staticmethod
+    def _unpack_serialized_job(doc:Dict[str, Any]) -> Tuple[str, str, Dict[str, Any]]:
+        """Fetches the Job Id, Handler Id, and serialized job representation from a Mongo
+        serialized Job record.
+
+        Arguments:
+            doc {Dict[str, any]} -- A JSON document serialized for the Job-bus database.
+
+        Raises:
+            Exception: Raised if the input document is not in the right format, as evidenced by
+            missing required keys.
+
+        Returns:
+            Tuple[str, str, Dict[str, Any]] -- Tuple of (Job_Id, handler_id, serialized_job)
+        """
+        required_keys = [JobKeys.SERIALIZATION, JobKeys.JOB_ID, JobHandlerKeys.HANDLER_ID]
+        for x in required_keys:
+            if x in doc: continue
+            raise Exception(f"Input document {doc} is missing required key {x}; is it really a serialized Job?")
+        job_id = doc[JobKeys.JOB_ID]
+        handler = doc[JobHandlerKeys.HANDLER_ID]
+        serialized_job = doc[JobKeys.SERIALIZATION]
+        return (job_id, handler, serialized_job)
+
+class JobHandlerKeys:
+    UTCTIME = 'utctime'
+    HANDLER_ID = 'handler_id'
+
+class ComputeResourceKeys:
+    COMPUTE_RESOURCE = JobKeys.COMPUTE_RESOURCE # alias, since these should have same value
+    KACHERY = 'kachery'
+    UTCTIME = 'utctime'

--- a/hither/_exceptions.py
+++ b/hither/_exceptions.py
@@ -1,0 +1,2 @@
+class DeserializationException(Exception):
+    pass

--- a/hither/_jobmanager.py
+++ b/hither/_jobmanager.py
@@ -55,8 +55,7 @@ class _JobManager:
             job.resolve_wrapped_job_values()
             if job._job_cache is not None:
                 if not job._job_handler.is_remote:
-                    job._job_cache.check_job(job)
-            # TODO: Do we actually do anything with the results of that check?
+                    job._job_cache.fetch_cached_job_results(job)
 
             job._job_handler.handle_job(job)
 

--- a/hither/_util.py
+++ b/hither/_util.py
@@ -1,3 +1,5 @@
+import time
+
 from typing import Union, List, Any, Callable
 import random
 from ._enums import HitherFileType
@@ -85,6 +87,20 @@ def _docker_form_of_container_string(container):
         return container[len('docker://'):]
     else:
         return container
+
+# NOTE: This can be centralized presently; used identically in computeresource and remotejobhandler.
+# If those ever need different polling interval setups, or if use broadens and we need something
+# more flexible, this can be popped back out easily enough.
+def _get_poll_interval(last_timestamp: float) -> float:
+    elapsed_time = time.time() - last_timestamp
+    if elapsed_time < 3:
+        return 0.1
+    elif elapsed_time < 20:
+        return 1
+    elif elapsed_time < 60:
+        return 3
+    else:
+        return 6
 
 def _random_string(num: int):
     """Generate random string of a given length.

--- a/hither/computeresource.py
+++ b/hither/computeresource.py
@@ -1,10 +1,14 @@
 import time
+from typing import Union, Optional, Dict, Any
+
 import kachery as ka
-from .core import _serialize_item, _deserialize_job, _prepare_container
+from .core import _serialize_item, _prepare_container
 from ._util import _random_string, _utctime
-from .database import Database
+from .database import Database, JobKeys
 from ._enums import JobStatus
+from ._exceptions import DeserializationException
 from .file import File
+from .job import Job
 
 # TODO: Functionalize, tighten.
 # TODO: Consider filtering db query/filter/update statements through an interface function.
@@ -21,214 +25,182 @@ class ComputeResource:
         self._timestamp_last_action = time.time()
         self._job_handler = job_handler
         self._job_cache = job_cache
-        self._jobs = dict()
+        self._jobs: Dict[str, Job] = dict()
+
     def clear(self):
-        db = self._get_db()
-        db.delete_many(dict(
-            compute_resource_id=self._compute_resource_id
-        ))
+        self._database._clear_jobs_for_compute_resource(self._compute_resource_id)
+
     def run(self):
         while True:
             self._iterate()
-            time.sleep(0.02)
-    def _iterate(self):
-        active_job_handler_ids = self._get_active_job_handler_ids()
+            time.sleep(0.02) # TODO: alternative to busy-wait?
 
+    def _iterate(self):
         self._iterate_timer = time.time()
-        db = self._get_db()
 
         elapsed_database_poll = time.time() - self._timestamp_database_poll
         if elapsed_database_poll > self._poll_interval():
-            self._timestamp_database_poll = time.time()
-
-            self._report_active()
-
-            # Handle pending jobs
-            query = dict(
-                compute_resource_id=self._compute_resource_id,
-                last_modified_by_compute_resource=False,
-                status=JobStatus.QUEUED.value,
-                compute_resource_status=JobStatus.PENDING.value  # status on the compute resource
-            )
-            for doc in db.find(query):
-                self._report_action()
-                self._handle_pending_job(doc)
+            self._handle_pending_jobs()
         
         # Handle jobs
         job_ids = list(self._jobs.keys())
         for job_id in job_ids:
             job = self._jobs[job_id]
-            reported_status = getattr(job, '_reported_status')
             if job._status == JobStatus.RUNNING:
-                if reported_status != JobStatus.RUNNING:
-                    print(f'Job running: {job_id}')
-                    filter0 = dict(
-                        compute_resource_id=self._compute_resource_id,
-                        job_id=job_id
-                    )
-                    update = {
-                        '$set': dict(
-                            status=JobStatus.RUNNING.value,
-                            compute_resource_status=JobStatus.RUNNING.value,
-                            last_modified_by_compute_resource=True
-                        )
-                    }
-                    db.update_one(filter0, update=update)
-                    self._report_action()
-                    setattr(job, '_reported_status', JobStatus.RUNNING)
+                self._mark_job_as_running(job=job)
             elif job._status == JobStatus.FINISHED:
-                print(f'Job finished: {job_id}')
                 self._handle_finished_job(job)
-                if self._job_cache is not None:
-                    self._job_cache.cache_job_result(job)
-                del self._jobs[job_id]
+                del self._jobs[job._job_id]
             elif job._status == JobStatus.ERROR:
-                # _print_console_out(job._runtime_info['console_out'])
-                print(job._exception)
-                print(f'Job error: {job_id}')
+                print(f"Job error: {job_id}\n{job._exception}")
                 self._mark_job_as_error(job_id=job_id, runtime_info=job._runtime_info, exception=job._exception)
-                del self._jobs[job_id]
-            
+                del self._jobs[job._job_id]
+            # TODO: Check for a canceled status
+            # TODO: Catch-all
+
+            self._report_action()
+
             # check if handler is still active
-            if job_id in self._jobs:
-                handler_id = getattr(job, '_handler_id')
-                if handler_id not in active_job_handler_ids:
-                    print(f'Removing job because client handler is no longer active: {job_id}')
-                    self._job_handler.cancel_job(job_id)
-                    filter0 = dict(
-                        compute_resource_id=self._compute_resource_id,
-                        job_id=job_id
-                    )
-                    db.delete_many(filter0)
-                    del self._jobs[job_id]
-        
+            self._clear_jobs_with_inactive_handlers()
         self._job_handler.iterate()
-    
-    def _get_active_job_handler_ids(self):
-        db = self._get_db(collection='active_job_handlers')
-        db_jobs = self._get_db()
 
-        # remove the expired job handlers
-        t0 = _utctime() - 10
-        query = dict(
-            utctime={'$lt': t0}
-        )
-        for doc in db.find(query):
-            handler_id = doc['handler_id']
-            print(f'Removing job handler: {handler_id}')
-            db.delete_many(dict(handler_id=handler_id))
-            db_jobs.delete_many(dict(handler_id=handler_id))
 
-        # return handler ids for those that were not removed
-        return [doc['handler_id'] for doc in db.find({})]
-    
+    def _clear_jobs_with_inactive_handlers(self):
+        active_handler_ids = self._database._get_active_job_handler_ids()
+        for job_id in self._jobs:
+            handler_id = self._jobs[job_id]._handler_id
+            if handler_id not in active_handler_ids:
+                print(f'Removing job because client handler is no longer active: {job_id}')
+                self._job_handler.cancel_job(job_id)
+                self._database._delete_job(job_id, self._compute_resource_id)
+                del self._jobs[job_id]
+
+    def _handle_pending_jobs(self):
+        self._timestamp_database_poll = time.time()
+        self._database._report_compute_resource_active(self._compute_resource_id, self._kachery)
+
+        for doc in self._database._fetch_pending_jobs(_compute_resource_id=self._compute_resource_id):
+            self._report_action()
+            self._handle_pending_job(doc)
+
     def _handle_pending_job(self, doc):
-        job_id = doc["job_id"]
-        label = doc['job_serialized']['label']
-        print(f'Queuing job: {label}')
+        job_id, handler_id, job_serialized = JobKeys._unpack_serialized_job(doc)
+        label = job_serialized[JobKeys.LABEL]
+        print(f'Queuing job: {label}') # TODO: Convert to log statement
         
-        job_serialized = doc['job_serialized']
-        if job_serialized['code'] is not None:
-            try:
-                code_obj = ka.load_object(job_serialized['code'], fr=self._kachery)
-                if code_obj is None:
-                    raise Exception("Kachery returned no serialized code for function.")
-                job_serialized['code'] = code_obj
-            except Exception as e:
-                exc = f'Error loading code for function {label}: {job_serialized["code"]} ({str(e)})'
-                print(exc)
-                self._mark_job_as_error(job_id=job_id, exception=Exception(exc), runtime_info=None)
+        if not (self._hydrate_code_for_serialized_job(job_id, job_serialized)
+                and self._hydrate_container_for_serialized_job(job_id, job_serialized)):
+            return
+       
+        job = Job._deserialize(job_serialized)
+        if self._job_cache:
+            self._job_cache.fetch_cached_job_results(job)
+            if job._status == JobStatus.FINISHED:
+                # TODO NOTE: These print statements are not correct; there's no check for a cache miss
+                print(f'Found job in cache: {label}') # TODO: Convert to log statement
+                self._handle_finished_job(job)
                 return
-        container = job_serialized['container']
+            elif job._status == JobStatus.ERROR:
+                print(f'Found error job in cache: {label}') # TODO: Convert to log statement; also might not be true
+                self._mark_job_as_error(job_id=job_id, exception=job._exception, runtime_info=job._runtime_info)
+                return
+        # No finished or errored version of the Job was found in the cache. Thus, queue it.
+        self._queue_job(job, handler_id)
+
+    def _hydrate_code_for_serialized_job(self, job_id:str, serialized_job:Dict[str, Any]) -> bool:
+        """Prepare contents of 'code' field for serialized Job.
+
+        Arguments:
+            job_id {str} -- Id of serialized Hither Job.
+            serialized_job {Dict[str, Any]} -- Dictionary corresponding to a serialized Hither Job.
+
+        Raises:
+            DeserializationException: Thrown if the serialized Job contains no code object known to
+            Kachery.
+
+        Returns:
+            bool -- True if processing may continue; False in the event of fatal error loading
+            serialized code object.
+        """
+        code = serialized_job[JobKeys.CODE]
+        label = serialized_job[JobKeys.LABEL]
+        if code is None:
+            return True
+        try:
+            code_obj = ka.load_object(code, fr=self._kachery)
+            if code_obj is None:
+                raise DeserializationException("Kachery returned no serialized code for function.")
+            serialized_job[JobKeys.CODE] = code_obj
+        except Exception as e:
+            exc = f'Error loading code for function {label}: {code} ({str(e)})'
+            print(exc)
+            self._mark_job_as_error(job_id=job_id, exception=Exception(exc), runtime_info=None)
+            return False
+        return True
+
+    def _hydrate_container_for_serialized_job(self, job_id:str, serialized_job:Dict[str, Any]) -> bool:
+        """Prepare container for serialized job, with error checking.
+
+        Arguments:
+            job_id {str} -- Id of serialized Hither Job.
+            serialized_job {Dict[str, Any]} -- Dictionary corresponding to a serialized Hither Job.
+
+        Returns:
+            bool -- True if successful or not needed; False if a fatal error occurred.
+        """
+        container = serialized_job[JobKeys.CONTAINER]
+        label = serialized_job[JobKeys.LABEL]
+
         if container is None:
             exc = f'Cannot run serialized job outside of container: {label}'
             print(exc)
             self._mark_job_as_error(job_id=job_id, exception=Exception(exc), runtime_info=None)
-            return
+            return False
         try:
             _prepare_container(container)
         except Exception as e:
-            print(f'Error preparing container for pending job: {label}')
-            print(e)
+            print(f"Error preparing container for pending job: {label}\n{e}")
             self._mark_job_as_error(job_id=job_id, exception=e, runtime_info=None)
-            return
-        
-        job = _deserialize_job(job_serialized)
-        if self._job_cache:
-            self._job_cache.check_job(job)
-        db = self._get_db()
-        filter0 = dict(
-            compute_resource_id=self._compute_resource_id,
-            job_id=doc['job_id']
-        )
-        if job._status == JobStatus.FINISHED:
-            print(f'Found job in cache: {label}')
-            self._handle_finished_job(job)
-        elif job._status == JobStatus.ERROR:
-            print(f'Found error job in cache: {label}')
-            self._mark_job_as_error(job_id=job_id, exception=job._exception, runtime_info=job._runtime_info)
-        else:
-            try:
-                job.download_parameter_files_if_needed(kachery=self._kachery)
-            except Exception as e:
-                print(f'Error downloading input files for job: {label}')
-                print(e)
-                self._mark_job_as_error(job_id=job_id, exception=e, runtime_info=None)
-                return
-            self._jobs[job_id] = job
-            self._job_handler.handle_job(job)
-            update = {
-                '$set': dict(
-                    compute_resource_status=JobStatus.QUEUED.value,
-                    last_modified_by_compute_resource=True
-                )
-            }
-            db.update_one(filter0, update=update)
-            setattr(job, '_reported_status', JobStatus.QUEUED)
-            setattr(job, '_handler_id', doc['handler_id'])
-    
+            return False
+        return True
+ 
     def _handle_finished_job(self, job):
+        print(f'Job finished: {job._job_id}') # TODO: Change to formal log statement?
         job.kache_results_if_needed(kachery=self._kachery)
-        self._mark_job_as_finished(job_id=job._job_id, runtime_info=job._runtime_info, result=job._result)
-    
-    def _mark_job_as_error(self, *, job_id, runtime_info, exception):
-        print(f'Job error: {job_id}')
-        db = self._get_db()
-        filter0 = dict(
-            compute_resource_id=self._compute_resource_id,
-            job_id=job_id
-        )
-        update = {
-            '$set': dict(
-                status=JobStatus.ERROR.value,
-                compute_resource_status=JobStatus.ERROR.value,
-                result=None,
-                runtime_info=runtime_info,
-                exception='{}'.format(exception),
-                last_modified_by_compute_resource=True
-            )
-        }
-        db.update_one(filter0, update=update)
-        self._report_action()
-    
-    def _mark_job_as_finished(self, *, job_id, runtime_info, result):
-        db = self._get_db()
-        filter0 = dict(
-            compute_resource_id=self._compute_resource_id,
-            job_id=job_id
-        )
-        update = {
-            '$set': dict(
-                status=JobStatus.FINISHED.value,
-                compute_resource_status=JobStatus.FINISHED.value,
-                result=_serialize_item(result),
-                runtime_info=runtime_info,
-                exception=None,
-                last_modified_by_compute_resource=True
-            )
-        }
-        db.update_one(filter0, update=update)
-        self._report_action()
+        self._mark_job_as_finished(job=job)
+        if self._job_cache is not None:
+            self._job_cache.cache_job_result(job)
+
+    def _queue_job(self, job:Job, handler_id:str) -> None:
+        try:
+            job.download_parameter_files_if_needed(kachery=self._kachery)
+        except Exception as e:
+            print(f"Error downloading input files for job: {job._label}\n{e}")
+            self._mark_job_as_error(job_id=job._job_id, exception=e, runtime_info=None)
+            return
+        self._jobs[job._job_id] = job
+        self._job_handler.handle_job(job)
+        job._reported_status = JobStatus.QUEUED
+        job._handler_id = handler_id
+        self._database._mark_job_as_queued(job._job_id, self._compute_resource_id)
+
+    def _mark_job_as_running(self, *, job: Job) -> None:
+        if job._reported_status == job._status:
+            return  # we know it's still running, nothing to see here
+        print(f"Job now running: {job._job_id}") # TODO: Formal log statement?
+        self._database._mark_job_as_running(job._job_id, self._compute_resource_id)
+        job._reported_status = JobStatus.RUNNING
+
+    def _mark_job_as_finished(self, *, job: Job) -> None:
+        serialized_result = _serialize_item(job._result)
+        self._database._mark_job_as_finished(job._job_id, self._compute_resource_id,
+            runtime_info=job._runtime_info, result=serialized_result)
+        
+    def _mark_job_as_error(self, *,
+            job_id: str, runtime_info: Optional[dict], exception: Optional[Exception]) -> None:
+        print(f'Job error: {job_id}') # TODO: Change to formal log statement?
+        self._database._mark_job_as_error(job_id, self._compute_resource_id,
+            runtime_info=runtime_info, exception=exception)
     
     def _report_action(self):
         self._timestamp_last_action = time.time()
@@ -243,19 +215,6 @@ class ComputeResource:
             return 3
         else:
             return 6
-    def _report_active(self):
-        db = self._get_db(collection='active_compute_resources')
-        filter = dict(
-            compute_resource_id=self._compute_resource_id
-        )
-        update = {
-            '$set': dict(
-                compute_resource_id=self._compute_resource_id,
-                kachery=self._kachery,
-                utctime=_utctime()
-            )
-        }
-        db.update_one(filter, update=update, upsert=True)
 
     def _get_db(self, collection='hither_jobs'):
         return self._database.collection(collection)

--- a/hither/database.py
+++ b/hither/database.py
@@ -1,28 +1,262 @@
+#from pymongo import MongoClient, collection, cursor (NOTE: This will hopefully be usable once TypeAlias
+# is part of the language, see PEP-613. TODO)
+
+from typing import Optional, Union, Any, Dict, List, Tuple
+
 from ._load_config import _load_preset_config_from_github
+from ._enums import JobStatus
+from .file import File
+from ._util import _utctime
+
 
 class Database:
-    def __init__(self, *, mongo_url, database):
-        self._mongo_url = mongo_url
-        self._database = database
-        self._client = None
-        self._client_db_url = None
+    HitherJobCollection = 'hither_jobs'
+    ActiveJobHandlers = 'active_job_handlers'
+    ActiveComputeResources = 'active_compute_resources'
+
+    def __init__(self, *, mongo_url: str, database: str):
+        """Wraps a connection to a Mongo database instance used to store jobs, and other Hither
+        job management data.
+
+        Arguments:
+            mongo_url {str} -- URL of the MongoDB instance, including password.
+            database {str} -- Name of the specific database storing Hither job information.
+        """
+        self._mongo_url: str = mongo_url
+        self._database: str = database
+        # self._client: Optional[MongoClient] = None
+        self._client: Optional[Any] = None
+        self._client_db_url: Optional[str] = None
+
+    # TODO NOTE: method only appears in remotejobhandler.
     @staticmethod
-    def preset(name):
-        config = _load_preset_config_from_github(url='https://raw.githubusercontent.com/flatironinstitute/hither/config/config/2020a.json', name=name)
-        mongo_url = config['mongo_url']
+    def preset(name: str) -> 'Database':
+        config: dict = _load_preset_config_from_github(url='https://raw.githubusercontent.com/flatironinstitute/hither/config/config/2020a.json', name=name)
+        mongo_url: str = config['mongo_url']
         if 'password' in config:
             mongo_url = mongo_url.replace('${password}', config['password'])
-        db = Database(mongo_url=mongo_url, database=config['database'])
+        db: 'Database' = Database(mongo_url=mongo_url, database=config['database'])
         return db
-    def collection(self, collection_name):
+
+# This actually returns a collection but there are issues with importing pymongo at file level
+    def collection(self, collection_name: str) -> Any:
         import pymongo
-        url = self._mongo_url
-        if url != self._client_db_url:
+        # NOTE: Neither of these values are changed in this codebase, nor should they be changed elsewhere?
+        if self._mongo_url != self._client_db_url:
             if self._client is not None:
                 self._client.close()
-            self._client = pymongo.MongoClient(url, retryWrites=False)
-            self._client_db_url = url
+            self._client = pymongo.MongoClient(self._mongo_url, retryWrites=False)
+            self._client_db_url = self._mongo_url
         return self._client[self._database][collection_name]
 
-    # TODO: Have this class be more responsible for mediating access to the jobs stored in the Mongo db.
-    # Can serve as a Job-class-aware interface.
+    def _make_update(self, update:Dict[str, Any]) -> Dict[str, Any]:
+        return { '$set': update }
+
+    def _get_active_job_handler_ids(self) -> List[str]:
+        self._clear_expired_job_handlers()
+        return [ x[JobHandlerKeys.HANDLER_ID] for x in self.collection(Database.ActiveJobHandlers).find() ]
+
+    def _clear_expired_job_handlers(self) -> None:
+        timeout_cutoff = _utctime() - 10 # TODO: IS THIS THE RIGHT INTERPRETATION?
+        query = { JobHandlerKeys.UTCTIME: { '$lt': timeout_cutoff } }
+        handler_ids:List[str] = [ x[JobHandlerKeys.HANDLER_ID]
+                                  for x in self.collection(Database.ActiveJobHandlers).find(query) ]
+        self.collection(Database.ActiveJobHandlers)\
+            .delete_many({ JobHandlerKeys.HANDLER_ID: { '$in': handler_ids } })
+        self.collection(Database.HitherJobCollection)\
+            .delete_many({ JobHandlerKeys.HANDLER_ID: { '$in': handler_ids } })
+        for id in handler_ids:
+            print(f'Removed job handler: {id}') # TODO: Make log
+
+    # This actually returns a cursor but there are issues with importing pymongo at file level
+    def _fetch_pending_jobs(self, *, _compute_resource_id: str) -> List[Any]:
+        query = {
+            JobKeys.COMPUTE_RESOURCE:_compute_resource_id,
+            JobKeys.LAST_MODIFIED_BY_COMPUTE_RESOURCE: False,
+            JobKeys.STATUS: JobStatus.QUEUED.value,
+            JobKeys.COMPUTE_RESOURCE_STATUS: JobStatus.PENDING.value  # status on the compute resource
+        }
+        return self.collection(Database.HitherJobCollection).find(query)
+
+    def _clear_jobs_for_compute_resource(self, compute_resource_id:str) -> None:
+        _filter = { JobKeys.COMPUTE_RESOURCE: compute_resource_id }
+        self.collection(Database.HitherJobCollection).delete_many(_filter)
+
+    def _delete_job(self, job_id:str, compute_resource:str) -> None:
+        _filter = {
+            JobKeys.JOB_ID: job_id,
+            JobKeys.COMPUTE_RESOURCE: compute_resource
+        }
+        self.collection(Database.HitherJobCollection)\
+            .delete_many(_filter)
+
+    def _mark_job_as_error(self, job_id:str, compute_resource:str, *,
+                            runtime_info: Optional[dict],
+                            exception: Optional[Exception]) -> None:
+        _filter = {
+            JobKeys.JOB_ID: job_id,
+            JobKeys.COMPUTE_RESOURCE: compute_resource
+        }
+        update_query = self._make_update({
+            JobKeys.STATUS: JobStatus.ERROR.value,
+            JobKeys.COMPUTE_RESOURCE_STATUS: JobStatus.ERROR.value,
+            JobKeys.RESULT: None,
+            JobKeys.RUNTIME_INFO: runtime_info,
+            JobKeys.EXCEPTION: f"{exception}",
+            JobKeys.LAST_MODIFIED_BY_COMPUTE_RESOURCE: True
+        })
+        self.collection(Database.HitherJobCollection)\
+            .update_one(_filter, update=update_query)
+
+    def _mark_job_as_finished(self, job_id:str, compute_resource:str, *,
+                                runtime_info: Optional[dict],
+                                result: Optional[Any]) -> None:
+        _filter = {
+            JobKeys.JOB_ID: job_id,
+            JobKeys.COMPUTE_RESOURCE: compute_resource
+        }
+        update_query = self._make_update({
+            JobKeys.STATUS: JobStatus.FINISHED.value,
+            JobKeys.COMPUTE_RESOURCE_STATUS: JobStatus.FINISHED.value,
+            JobKeys.RESULT: result,
+            JobKeys.RUNTIME_INFO: runtime_info,
+            JobKeys.EXCEPTION: None,
+            JobKeys.LAST_MODIFIED_BY_COMPUTE_RESOURCE: True
+        })
+        self.collection(Database.HitherJobCollection)\
+            .update_one(_filter, update=update_query)
+
+    def _mark_job_as_queued(self, job_id:str, compute_resource:str) -> None:
+        _filter = {
+            JobKeys.JOB_ID: job_id,
+            JobKeys.COMPUTE_RESOURCE: compute_resource
+        }
+        update_query = self._make_update({
+            JobKeys.COMPUTE_RESOURCE_STATUS: JobStatus.QUEUED.value,
+            JobKeys.LAST_MODIFIED_BY_COMPUTE_RESOURCE: True
+        })
+        self.collection(Database.HitherJobCollection)\
+            .update_one(_filter, update=update_query)
+
+    def _mark_job_as_running(self, job_id:str, compute_resource:str) -> None:
+        _filter = {
+            JobKeys.COMPUTE_RESOURCE: compute_resource,
+            JobKeys.JOB_ID: job_id
+        }
+        update_query = self._make_update({
+            JobKeys.STATUS: JobStatus.RUNNING.value,
+            JobKeys.COMPUTE_RESOURCE_STATUS: JobStatus.RUNNING.value,
+            JobKeys.LAST_MODIFIED_BY_COMPUTE_RESOURCE: True
+        })
+        self.collection(Database.HitherJobCollection)\
+            .update_one(_filter, update=update_query)
+
+    def _report_compute_resource_active(self, resource_id:str, kachery:str) -> None:
+        _filter = { JobKeys.COMPUTE_RESOURCE: resource_id }
+        update_query = self._make_update({
+            JobKeys.COMPUTE_RESOURCE: resource_id,
+            ComputeResourceKeys.KACHERY: kachery,
+            ComputeResourceKeys.UTCTIME: _utctime()
+        })
+        self.collection(Database.ActiveComputeResources)\
+            .update_one(_filter, update=update_query, upsert=True)
+
+# TODO: Put this somewhere else, in a Constants file or something
+# (or else make it part of the Job class)
+# NOTE: It probably belongs somewhere closer to serialization/deserialization code too...
+class JobKeys:
+    CODE = 'code'
+    COMPUTE_RESOURCE = 'compute_resource_id'
+    COMPUTE_RESOURCE_STATUS = 'compute_resource_status' # the Job's status on the remote resource.
+    CONTAINER = 'container'
+    DOWNLOAD_RESULTS = 'download_results'
+    EXCEPTION = 'exception'
+    FUNCTION = 'function'
+    FUNCTION_NAME = 'function_name'
+    FUNCTION_VERSION = 'function_version'
+    JOB_ID = 'job_id'
+    JOB_TIMEOUT = 'job_timeout'
+    LABEL = 'label'
+    # represents whether the job state was last changed by the compute resource (as opposed to
+    # by the local job handler)
+    LAST_MODIFIED_BY_COMPUTE_RESOURCE = 'last_modified_by_compute_resource'
+    NO_RESOLVE_INPUT_FILES = 'no_resolve_input_files'
+    RESULT = 'result'
+    RUNTIME_INFO = 'runtime_info'
+    SERIALIZATION_LABEL = 'job_serialized'
+    STATUS = 'status'
+    WRAPPED_ARGS = 'kwargs' # TODO CHANGE ME ONCE ALL REFERENCES ARE CENTRALIZED
+
+    @staticmethod
+    def _verify_serialized_job(doc:Dict[str, any]) -> bool:
+        """Checks an input dictionary (expected to correspond to a Job serialized to MongoDB job
+        monitor bus) for a bare minimum of required keys to establish it is actually a Job object.
+
+        Arguments:
+            doc {Dict[str, any]} -- Dictionary of fields corresponding to a Hither Job.
+
+        Returns:
+            bool -- True if required fields are present; else False.
+        """
+        required_keys = [
+            JobKeys.LABEL,
+            JobKeys.CODE,
+            JobKeys.CONTAINER
+        ]
+        for x in required_keys:
+            if not x in doc: return False
+        return True
+
+    @staticmethod
+    def _unpack_serialized_job(doc:Dict[str, Any]) -> Tuple[str, str, Dict[str, Any]]:
+        """Fetches the Job Id, Handler Id, and serialized job representation from a Mongo
+        serialized Job record.
+
+        Arguments:
+            doc {Dict[str, any]} -- A JSON document serialized for the Job-bus database.
+
+        Raises:
+            Exception: Raised if the input document is not in the right format, as evidenced by
+            missing required keys.
+
+        Returns:
+            Tuple[str, str, Dict[str, Any]] -- Tuple of (Job_Id, handler_id, serialized_job)
+        """
+        required_keys = [JobKeys.SERIALIZATION_LABEL, JobKeys.JOB_ID, JobHandlerKeys.HANDLER_ID]
+        for x in required_keys:
+            if x in doc: continue
+            raise Exception(f"Input document {doc} is missing required key {x}; is it really a serialized Job?")
+        job_id = doc[JobKeys.JOB_ID]
+        handler = doc[JobHandlerKeys.HANDLER_ID]
+        serialized_job = doc[JobKeys.SERIALIZATION_LABEL]
+        return (job_id, handler, serialized_job)
+
+    # @staticmethod
+    # def _get_serialized_job_data(doc:Dict[str, Any]) -> Tuple[str, Optional[str], Any]:
+    #     """Pulls label, container, and code from a serialized job record for deserialization preprocessing.
+
+    #     Arguments:
+    #         doc {Dict[str, Any]} -- JSON document representing a serialized Hither Job.
+
+    #     Raises:
+    #         Exception: Raised if the input document is not in the right format, as evidenced by
+    #         missing required keys.
+
+    #     Returns:
+    #         Tuple[str, Optional[str], Any] -- Tuple of (label, container, code) for serialized Job.
+    #     """
+    #     if not JobKeys._verify_serialized_job(doc):
+    #         raise Exception(f"Input document {doc} lacks keys required for a serialized Job.")
+    #     label = doc[JobKeys.LABEL]
+    #     container = doc[JobKeys.CONTAINER]
+    #     code = doc[JobKeys.CODE]
+    #     return (label, container, code)
+
+class JobHandlerKeys:
+    UTCTIME = 'utctime'
+    HANDLER_ID = 'handler_id'
+
+class ComputeResourceKeys:
+    COMPUTE_RESOURCE = JobKeys.COMPUTE_RESOURCE # alias, since these should have same value
+    KACHERY = 'kachery'
+    UTCTIME = 'utctime'

--- a/hither/job.py
+++ b/hither/job.py
@@ -379,7 +379,19 @@ class Job:
         # we could properly check that for it.
         return True
 
+    def _compute_hash(self) -> str:
+        hash_object = {
+            JobKeys.FUNCTION_NAME: self._function_name,
+            JobKeys.FUNCTION_VERSION: self._function_version,
+            JobKeys.WRAPPED_ARGS: _serialize_item(self._wrapped_function_arguments)
+        }
+        if self._no_resolve_input_files:
+            hash_object[JobKeys.NO_RESOLVE_INPUT_FILES] = True
+        return ka.get_object_hash(hash_object)
     
+    def _serialized_result(self) -> Any:
+        return _serialize_item(self._result)
+
     def _serialize(self, generate_code:bool):
         function_name = self._function_name
         function_version = self._function_version

--- a/hither/job.py
+++ b/hither/job.py
@@ -6,8 +6,7 @@ from typing import Dict, List, Union, Any, Optional
 
 import kachery as ka
 from ._Config import Config
-from .database import JobKeys
-from ._enums import JobStatus
+from ._enums import JobStatus, JobKeys
 from .file import File
 from ._generate_source_code_for_function import _generate_source_code_for_function
 from .remotejobhandler import RemoteJobHandler

--- a/hither/job.py
+++ b/hither/job.py
@@ -1,6 +1,4 @@
 from copy import deepcopy
-import os
-import sys
 import time
 from typing import Dict, List, Union, Any, Optional
 
@@ -9,9 +7,8 @@ from ._Config import Config
 from ._enums import JobStatus, JobKeys
 from .file import File
 from ._generate_source_code_for_function import _generate_source_code_for_function
-from .remotejobhandler import RemoteJobHandler
 from ._run_serialized_job_in_container import _run_serialized_job_in_container
-from ._util import _random_string, _docker_form_of_container_string, _deserialize_item, _serialize_item, _flatten_nested_collection, _copy_structure_with_changes
+from ._util import _random_string, _deserialize_item, _serialize_item, _flatten_nested_collection, _copy_structure_with_changes
 
 
 
@@ -111,11 +108,6 @@ class Job:
             # Not the same as the job timeout... this is the wait timeout
             if timeout is not None and elapsed > timeout:
                 return None
-
-    def status(self) -> JobStatus:
-        # TODO: use the Deprecated package: https://pypi.org/project/Deprecated/
-        # To deprecate
-        return self.get_status()
 
     def get_status(self) -> JobStatus:
         return self._status
@@ -218,17 +210,7 @@ class Job:
         self._label = label
         return self
 
-    def set(self, *, label=None):
-        # to deprecate
-        if label is not None:
-            self.set_label(label)
-        return self
-
-    def runtime_info(self):
-        # To deprecate
-        return self.get_runtime_info()
-    
-    def get_runtime_info(self):
+    def get_runtime_info(self): # NOTE: Unused
         return deepcopy(self._runtime_info)
 
     def _execute(self):

--- a/hither/jobcache.py
+++ b/hither/jobcache.py
@@ -1,27 +1,36 @@
 from typing import Dict, List, Union, Any
 
-import kachery as ka
-from .database import Database, JobKeys
-from ._util import _deserialize_item, _flatten_nested_collection
-from ._enums import JobStatus
-from .file import File
+from .database import Database
+from ._util import _deserialize_item
+from ._enums import JobStatus, JobKeys
 from .job import Job
 
 class JobCache:
-    def __init__(self, database: Database, cache_failing=False, rerun_failing=False, force_run=False):
+    def __init__(self, database: Database, cache_failing:bool=False,
+                    rerun_failing:bool=False, force_run:bool=False):
         self._database = database
         self._cache_failing = cache_failing
         self._rerun_failing = rerun_failing
         self._force_run = force_run
 
     def fetch_cached_job_results(self, job: Job) -> bool:
+        """Replaces completed Jobs with their result from cache, and returns whether the cache
+        hit or missed.
+
+        Arguments:
+            job {Job} -- Job to look for in the job cache.
+
+        Returns:
+            bool -- True if an acceptable cached result was found. False if the Job has not run,
+            is unknown, or returned an error (and we're set to rerun errored Jobs).
+        """
         if self._force_run:
             return False
         job_dict = self._database._fetch_cached_job(job._compute_hash())
         if job_dict is None:
             return False
 
-        status = job_dict[JobKeys.STATUS]
+        status:JobStatus = JobStatus(job_dict[JobKeys.STATUS])
         if status not in JobStatus.complete_statuses():
             return False
 
@@ -46,10 +55,8 @@ class JobCache:
         job._runtime_info = job_dict[JobKeys.RUNTIME_INFO]
         return True
 
-    def cache_job_result(self, job):
-        assert isinstance(job._status, JobStatus)
-        if job._status == JobStatus.ERROR:
-            if not self._cache_failing:
-                return
+    def cache_job_result(self, job:Job):
+        if job._status == JobStatus.ERROR and not self._cache_failing:
+            return 
         self._database._cache_job_result(job)
         

--- a/hither/jobcache.py
+++ b/hither/jobcache.py
@@ -1,14 +1,12 @@
 from typing import Dict, List, Union, Any
 
 import kachery as ka
-from .database import Database
+from .database import Database, JobKeys
 from ._util import _deserialize_item, _flatten_nested_collection
 from ._enums import JobStatus
 from .file import File
 from .job import Job
 
-# TODO: provide wrapper for calls to Database
-# TODO: Handle checking for locality of files (may need to pull out that function from Job.py)
 class JobCache:
     def __init__(self, database: Database, cache_failing=False, rerun_failing=False, force_run=False):
         self._database = database
@@ -19,74 +17,39 @@ class JobCache:
     def fetch_cached_job_results(self, job: Job) -> bool:
         if self._force_run:
             return False
-        hash0 = self._compute_job_hash(job)
-        query = dict(
-            hash=hash0
-        )
-        db = self._database.collection('cached_job_results')
-        doc = db.find_one(query)
-        if doc is None:
-            return False
-        if 'status' not in doc or doc['status'] not in JobStatus.complete_statuses():
+        job_dict = self._database._fetch_cached_job(job._compute_hash())
+        if job_dict is None:
             return False
 
-        if doc['status'] == JobStatus.FINISHED:
-            result0 = _deserialize_item(doc['result'])
-            if not _check_file_results_exist_locally(result0):
-                print(f'Found result in cache, but files do not exist locally: {job._label}')
-                # TODO: Is there a way we could recover from this situation? Like... try to download it?
+        status = job_dict[JobKeys.STATUS]
+        if status not in JobStatus.complete_statuses():
+            return False
+
+        job_description = f"{job._label} ({job._function_name} {job._function_version})"
+        if status == JobStatus.FINISHED:
+            result = _deserialize_item(job_dict[JobKeys.RESULT])
+            if not job._result_files_are_available_locally():
+                print(f'Found result in cache, but files do not exist locally: {job_description}')  # TODO: Make log
                 return False
-            job._result = result0 # TODO: Can combine this with below? See what happens if not set?
+            job._result = result
             job._exception = None
-            print(f'Using cached result for job: {job._label} ({job._function_name} {job._function_version})')
-        elif doc['status'] == JobStatus.ERROR:
+            print(f'Using cached result for job: {job_description}') # TODO: Make log
+        elif status == JobStatus.ERROR:
+            exception = job_dict[JobKeys.EXCEPTION]
             if self._cache_failing and (not self._rerun_failing):
                 job._result = None
-                job._exception = Exception(doc['exception']) # TODO: Can combine with above? What if unset?
-                print(f'Using cached error for job: {job._label} ({job._function_name} {job._function_version})')
+                job._exception = Exception(exception)
+                print(f'Using cached error for job: {job_description}') # TODO: Make log
             else:
                 return False
-        job._status = doc['status']
-        job._runtime_info = doc['runtime_info']
+        job._status = status
+        job._runtime_info = job_dict[JobKeys.RUNTIME_INFO]
         return True
 
-
     def cache_job_result(self, job):
-        from .core import _serialize_item
         assert isinstance(job._status, JobStatus)
         if job._status == JobStatus.ERROR:
             if not self._cache_failing:
                 return
-        hash0 = self._compute_job_hash(job)
-        db = self._database.collection('cached_job_results')
-        query = dict(
-            hash=hash0
-        )
-        update = {
-            '$set': dict(
-                hash=hash0,
-                status=job._status.value,
-                result=_serialize_item(job._result),
-                runtime_info=job._runtime_info,
-                exception='{}'.format(job._exception)
-            )
-        }
-        db.update_one(query, update, upsert=True)
-
-    def _compute_job_hash(self, job):
-        from .core import _serialize_item
-        hash_object = dict(
-            function_name=job._function_name,
-            function_version=job._function_version,
-            kwargs=_serialize_item(job._wrapped_function_arguments)
-        )
-        if job._no_resolve_input_files:
-            hash_object['no_resolve_input_files'] = True
-        return ka.get_object_hash(hash_object)
-
-def _check_file_results_exist_locally(x):
-    files = _flatten_nested_collection(x, _type=File)
-    for f in files:
-        local_path = ka.get_file_info(f._sha1_path, fr=None)
-        if local_path is None: return False
-    return True
+        self._database._cache_job_result(job)
+        

--- a/hither/jobcache.py
+++ b/hither/jobcache.py
@@ -5,6 +5,7 @@ from .database import Database
 from ._util import _deserialize_item, _flatten_nested_collection
 from ._enums import JobStatus
 from .file import File
+from .job import Job
 
 # TODO: provide wrapper for calls to Database
 # TODO: Handle checking for locality of files (may need to pull out that function from Job.py)
@@ -15,7 +16,7 @@ class JobCache:
         self._rerun_failing = rerun_failing
         self._force_run = force_run
 
-    def check_job(self, job) -> bool:
+    def fetch_cached_job_results(self, job: Job) -> bool:
         if self._force_run:
             return False
         hash0 = self._compute_job_hash(job)

--- a/hither/remotejobhandler.py
+++ b/hither/remotejobhandler.py
@@ -1,14 +1,13 @@
 from types import SimpleNamespace
 import time
-from typing import Dict
+from typing import Dict, Any
 import kachery as ka
-#from hither import _deserialize_item
 from ._basejobhandler import BaseJobHandler
 from .database import Database
-from ._enums import JobStatus
+from ._enums import JobStatus, JobKeys
 from .file import File
 from ._load_config import _load_preset_config_from_github
-from ._util import _random_string, _utctime, _deserialize_item, _flatten_nested_collection
+from ._util import _random_string, _deserialize_item, _flatten_nested_collection, _get_poll_interval
 
 class RemoteJobHandler(BaseJobHandler):
     def __init__(self, *, database: Database, compute_resource_id):
@@ -28,26 +27,11 @@ class RemoteJobHandler(BaseJobHandler):
             num_finished_jobs=0,
             num_errored_jobs=0
         )
+        self._kachery = database._get_active_compute_resource_kachery_handle(compute_resource_id)
 
-        db1 = self._get_db(collection='active_compute_resources')
-        t0 = _utctime() - 20
-        query = dict(
-            compute_resource_id=compute_resource_id,
-            utctime={'$gt': t0}
-        )
-        doc = None
-        for _ in range(5):
-            doc = db1.find_one(query)
-            if doc is not None:
-                break
-            time.sleep(0.5)
-        if doc is None:
-            raise Exception(f'No active compute resource found: {compute_resource_id}')
-        self._kachery = doc['kachery']
-    
     @staticmethod
     def preset(name):
-        db = Database.preset(name)
+        db = Database.load_preset_config(name)
         config = _load_preset_config_from_github(url='https://raw.githubusercontent.com/flatironinstitute/hither/config/config/2020a.json', name=name)
         return RemoteJobHandler(database=db, compute_resource_id=config['compute_resource_id'])
 
@@ -60,24 +44,13 @@ class RemoteJobHandler(BaseJobHandler):
             self._send_file_as_needed(f)
 
         job_serialized = job._serialize(generate_code=True)
-        # send the code to the kachery
-        job_serialized['code'] = ka.store_object(job_serialized['code'], to=self._kachery)
-        db = self._get_db()
-        doc = dict(
-            compute_resource_id=self._compute_resource_id,
-            handler_id=self._handler_id,
-            job_id=job._job_id,
-            job_serialized=job_serialized,
-            status=JobStatus.QUEUED.value,
-            compute_resource_status=JobStatus.PENDING.value,
-            runtime_info=None,
-            result=None,
-            last_modified_by_compute_resource=False,
-            client_code=None
-        )
-        db.insert_one(doc)
+        # the CODE member is a big block of code text. Send it to kachery & replace with a hash ref
+        job_serialized[JobKeys.CODE] = ka.store_object(job_serialized[JobKeys.CODE], to=self._kachery)
+        self._database.add_pending_job(compute_resource_id=self._compute_resource_id,
+                                    handler_id=self._handler_id,
+                                    job_id = job._job_id,
+                                    job_serialized=job_serialized)
         self._jobs[job._job_id] = job
-
         self._report_action()
     
     def cancel_job(self, job_id):
@@ -85,105 +58,70 @@ class RemoteJobHandler(BaseJobHandler):
     
     def iterate(self) -> None:
         elapsed_database_poll = time.time() - self._timestamp_database_poll
-        if elapsed_database_poll <= self._poll_interval():
+        if elapsed_database_poll <= _get_poll_interval(self._timestamp_last_action):
             return
 
         self._timestamp_database_poll = time.time()
         self._report_active()
 
-        self._iterate_timer = time.time()
-        db = self._get_db()
-        client_code = _random_string(15)
-        query = dict(
-            compute_resource_id=self._compute_resource_id,
-            handler_id=self._handler_id,
-            last_modified_by_compute_resource=True
-        )
-        update = {
-            '$set': dict(
-                last_modified_by_compute_resource=False,
-                client_code=client_code
-            )
-        }
-
-        db.update_many(query, update=update)
-        for doc in db.find(dict(client_code=client_code)):
+        # self._iterate_timer = time.time() # Never actually used
+        for doc in self._database._fetch_remote_modified_jobs(
+                compute_resource_id=self._compute_resource_id,
+                handler_id = self._handler_id):
             self._report_action()
-            job_id = doc['job_id']
-            if job_id in self._jobs:
-                j = self._jobs[job_id]
-                compute_resource_status = JobStatus(doc['compute_resource_status'])
-                if compute_resource_status == JobStatus.QUEUED:
-                    print(f'Job queued: {job_id}')
-                elif compute_resource_status == JobStatus.RUNNING:
-                    print(f'Job running: {job_id}')
-                elif compute_resource_status == JobStatus.FINISHED:
-                    print(f'Job finished: {job_id}')
-                    self._internal_counts.num_finished_jobs += 1
-                    j._runtime_info = doc['runtime_info']
-                    j._status = JobStatus.FINISHED
-                    j._result = _deserialize_item(doc['result'])
-                    for f in _flatten_nested_collection(j._result, _type=File):
-                        setattr(f, '_remote_job_handler', self)
-                    del self._jobs[job_id]
-                elif compute_resource_status == JobStatus.ERROR:
-                    print(f'Job error: {job_id}')
-                    self._internal_counts.num_errored_jobs += 1
-                    j._runtime_info = doc['runtime_info']
-                    j._status = JobStatus.ERROR
-                    j._exception = Exception(doc['exception'])
-                    del self._jobs[job_id]
-                else:
-                    raise Exception(f'Unexpected compute resource status: {compute_resource_status}')
+            job_id = doc[JobKeys.JOB_ID]
+            if job_id not in self._jobs:
+                continue    # Is it worth interrogating this if it happens?
+            compute_resource_status = JobStatus(doc[JobKeys.COMPUTE_RESOURCE_STATUS])
+            if compute_resource_status not in JobStatus.local_statuses():
+                raise Exception(f'Unexpected compute resource status: {compute_resource_status}')
+            print(f"Job {compute_resource_status.value}: {job_id}") # TODO: Make formal log?
+            if compute_resource_status == JobStatus.FINISHED:
+                self._handle_finished_job(doc)
+            elif compute_resource_status == JobStatus.ERROR:
+                self._handle_error_job(doc)
 
-    
+    def _handle_finished_job(self, serialized_job:Dict[str, Any]) -> None:
+        job_id = serialized_job[JobKeys.JOB_ID]
+        job = self._jobs[job_id]
+        self._internal_counts.num_finished_jobs += 1
+        job._runtime_info = serialized_job[JobKeys.RUNTIME_INFO]
+        job._status = JobStatus.FINISHED
+        job._result = _deserialize_item(serialized_job[JobKeys.RESULT])
+        for f in _flatten_nested_collection(job._result, _type=File):
+            setattr(f, '_remote_job_handler', self)
+        del self._jobs[job_id]
+
+    def _handle_error_job(self, serialized_job:Dict[str, Any]) -> None:
+        job_id = serialized_job[JobKeys.JOB_ID]
+        job = self._jobs[job_id]
+        self._internal_counts.num_errored_jobs += 1
+        job._runtime_info = serialized_job['runtime_info']
+        job._status = JobStatus.ERROR
+        job._exception = Exception(serialized_job['exception'])
+        del self._jobs[job_id]
+
     def _load_file(self, sha1_path):
         return ka.load_file(sha1_path, fr=self._kachery)
 
     def _send_file_as_needed(self, x:File) -> None:
-        if self._kachery is None: return # No file store; nothing we can do.
-        # TODO: Should this case raise an exception?
+        if self._kachery is None: return # We have no file store; nothing we can do.
 
         remote_handler = getattr(x, '_remote_job_handler', None)
         if remote_handler is None:
             if self._compute_resource_id is None: return
             ka.store_file(x.path, to=self._kachery)
-        else:   # A remote handler is configured.
-            x_compute_resource_id = remote_handler._compute_resource_id
-            #  If we *are* the remote handler, we don't need to do anything.
-            if x_compute_resource_id == self._compute_resource_id:
+        else: 
+            #  If we're the remote handler, we don't need to do anything.
+            if remote_handler._compute_resource_id == self._compute_resource_id:
                 return
             raise Exception('This case not yet supported (we need to transfer data from one compute resource to another)')
         
     def _report_active(self):
-        db = self._get_db(collection='active_job_handlers')
-        filter = dict(
-            handler_id=self._handler_id
-        )
-        update = {
-            '$set': dict(
-                handler_id=self._handler_id,
-                utctime=_utctime()
-            )
-        }
-        db.update_one(filter, update=update, upsert=True)
+        self._database._report_job_handler_active(self._handler_id)
     
     def _report_action(self):
         self._timestamp_last_action = time.time()
 
-    def _poll_interval(self):
-        elapsed_since_last_action = time.time() - self._timestamp_last_action
-        if elapsed_since_last_action < 3:
-            return 0.1
-        elif elapsed_since_last_action < 20:
-            return 1
-        elif elapsed_since_last_action < 60:
-            return 3
-        else:
-            return 6
-
     def cleanup(self):
         pass
-
-    def _get_db(self, collection='hither_jobs'):
-        return self._database.collection(collection)

--- a/tests/old_test_1.py
+++ b/tests/old_test_1.py
@@ -1,293 +1,293 @@
-import os
-import time
-import json
-import hither as hi
-import pytest
-import numpy as np
-import kachery as ka
-from .functions import functions as fun
-from .fixtures import MONGO_PORT, DATABASE_NAME, COMPUTE_RESOURCE_ID, KACHERY_CONFIG
+# import os
+# import time
+# import json
+# import hither as hi
+# import pytest
+# import numpy as np
+# import kachery as ka
+# from .functions import functions as fun
+# from .fixtures import MONGO_PORT, DATABASE_NAME, COMPUTE_RESOURCE_ID, KACHERY_CONFIG
 
-def _run_pipeline(*, delay=None, shape=(6, 3)):
-    f = fun.zeros.run(shape=(6, 3))
-    g = fun.add.run(x=f, y=1)
-    with hi.Config(download_results=True):
-        A = fun.identity.run(x=g)
-    A.wait(0.1) # For code coverage
-    a = A.wait().array()
-    print('===========================================================')
-    print(a)
-    print('===========================================================')
-    assert a.shape == shape
-    assert np.allclose(a, np.ones(shape))
+# def _run_pipeline(*, delay=None, shape=(6, 3)):
+#     f = fun.zeros.run(shape=(6, 3))
+#     g = fun.add.run(x=f, y=1)
+#     with hi.Config(download_results=True):
+#         A = fun.identity.run(x=g)
+#     A.wait(0.1) # For code coverage
+#     a = A.wait().array()
+#     print('===========================================================')
+#     print(a)
+#     print('===========================================================')
+#     assert a.shape == shape
+#     assert np.allclose(a, np.ones(shape))
 
-def _run_short_pipeline(*, delay=None, shape=(6, 3)):
-    f = fun.zeros.run(shape=(6, 3))
-    with hi.Config(download_results=True):
-        A = fun.identity.run(x=f)
-    A.wait(0.1) # For code coverage
-    a = A.wait().array()
-    assert a.shape == shape
-    assert np.allclose(a, np.zeros(shape))
+# def _run_short_pipeline(*, delay=None, shape=(6, 3)):
+#     f = fun.zeros.run(shape=(6, 3))
+#     with hi.Config(download_results=True):
+#         A = fun.identity.run(x=f)
+#     A.wait(0.1) # For code coverage
+#     a = A.wait().array()
+#     assert a.shape == shape
+#     assert np.allclose(a, np.zeros(shape))
 
-def test_1(general, mongodb):
-    _run_pipeline()
-    with hi.ConsoleCapture(label='[test_1]') as cc:
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        jc = hi.JobCache(database=db)
-        with hi.Config(container=True, job_cache=jc):
-            for num in range(2):
-                timer = time.time()
-                _run_pipeline()
-                elapsed = time.time() - timer
-                print(f'Elapsed for pass {num}: {elapsed}')
-                if num == 1:
-                    assert elapsed < 2
-        cc.runtime_info() # for code coverage
+# def test_1(general, mongodb):
+#     _run_pipeline()
+#     with hi.ConsoleCapture(label='[test_1]') as cc:
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         jc = hi.JobCache(database=db)
+#         with hi.Config(container=True, job_cache=jc):
+#             for num in range(2):
+#                 timer = time.time()
+#                 _run_pipeline()
+#                 elapsed = time.time() - timer
+#                 print(f'Elapsed for pass {num}: {elapsed}')
+#                 if num == 1:
+#                     assert elapsed < 2
+#         cc.runtime_info() # for code coverage
 
-@pytest.mark.focus
-@pytest.mark.compute_resource
-def test_2(general, compute_resource, mongodb, kachery):
-    with hi.ConsoleCapture(label='[test_2]'):
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
-        with hi.Config(job_handler=rjh, container=True):
-            for num in range(2):
-                timer = time.time()
-                _run_short_pipeline(delay=1)
-                elapsed = time.time() - timer
-                print(f'Elapsed for pass {num}: {elapsed}')
-                if num == 1:
-                    assert elapsed < 2
-            with hi.Config(download_results=True):
-                _run_pipeline(shape=(6, 3))
-        hi.wait() # for code coverage
+# @pytest.mark.focus
+# @pytest.mark.compute_resource
+# def test_2(general, compute_resource, mongodb, kachery):
+#     with hi.ConsoleCapture(label='[test_2]'):
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+#         with hi.Config(job_handler=rjh, container=True):
+#             for num in range(2):
+#                 timer = time.time()
+#                 _run_short_pipeline(delay=1)
+#                 elapsed = time.time() - timer
+#                 print(f'Elapsed for pass {num}: {elapsed}')
+#                 if num == 1:
+#                     assert elapsed < 2
+#             with hi.Config(download_results=True):
+#                 _run_pipeline(shape=(6, 3))
+#         hi.wait() # for code coverage
 
-def test_file_lock(general, tmp_path):
-    # For code coverage
-    with hi.ConsoleCapture(label='[test_file_lock]'):
-        path = str(tmp_path)
-        with hi.FileLock(path + '/testfile.txt', exclusive=False):
-            pass
-        with hi.FileLock(path + '/testfile.txt', exclusive=True):
-            pass
+# def test_file_lock(general, tmp_path):
+#     # For code coverage
+#     with hi.ConsoleCapture(label='[test_file_lock]'):
+#         path = str(tmp_path)
+#         with hi.FileLock(path + '/testfile.txt', exclusive=False):
+#             pass
+#         with hi.FileLock(path + '/testfile.txt', exclusive=True):
+#             pass
 
-def test_misc(general):
-    # For code coverage
-    import pytest
-    with hi.ConsoleCapture(label='[test_misc]'):
-        f = fun.zeros.run(shape=(3, 4), delay=0)
-        with pytest.raises(Exception):
-            f.result()
-        f.wait()
-        f.result()
+# def test_misc(general):
+#     # For code coverage
+#     import pytest
+#     with hi.ConsoleCapture(label='[test_misc]'):
+#         f = fun.zeros.run(shape=(3, 4), delay=0)
+#         with pytest.raises(Exception):
+#             f.result()
+#         f.wait()
+#         f.result()
 
-@pytest.mark.compute_resource
-def test_job_error(general, compute_resource, mongodb, kachery):
-    import pytest
+# @pytest.mark.compute_resource
+# def test_job_error(general, compute_resource, mongodb, kachery):
+#     import pytest
     
-    with hi.ConsoleCapture(label='[test_job_error]'):
-        x = fun.intentional_error.run()
-        with pytest.raises(Exception):
-            a = x.wait()
-        assert str(x.exception()) == 'intentional-error'
+#     with hi.ConsoleCapture(label='[test_job_error]'):
+#         x = fun.intentional_error.run()
+#         with pytest.raises(Exception):
+#             a = x.wait()
+#         assert str(x.exception()) == 'intentional-error'
 
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
-        with hi.Config(job_handler=rjh, container=True):
-            for _ in range(2):
-                x = fun.intentional_error.run()
-                with pytest.raises(Exception):
-                    a = x.wait()
-                assert str(x.exception()) == 'intentional-error'
-        jc = hi.JobCache(database=db, cache_failing=True)
-        with hi.Config(job_cache=jc, container=True):
-            for _ in range(2):
-                x = fun.intentional_error.run()
-                with pytest.raises(Exception):
-                    a = x.wait()
-                assert str(x.exception()) == 'intentional-error'
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+#         with hi.Config(job_handler=rjh, container=True):
+#             for _ in range(2):
+#                 x = fun.intentional_error.run()
+#                 with pytest.raises(Exception):
+#                     a = x.wait()
+#                 assert str(x.exception()) == 'intentional-error'
+#         jc = hi.JobCache(database=db, cache_failing=True)
+#         with hi.Config(job_cache=jc, container=True):
+#             for _ in range(2):
+#                 x = fun.intentional_error.run()
+#                 with pytest.raises(Exception):
+#                     a = x.wait()
+#                 assert str(x.exception()) == 'intentional-error'
 
-@pytest.mark.compute_resource
-def test_bad_container(general, compute_resource, mongodb, kachery):
-    import pytest
+# @pytest.mark.compute_resource
+# def test_bad_container(general, compute_resource, mongodb, kachery):
+#     import pytest
     
-    with hi.ConsoleCapture(label='[test_bad_container]'):
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+#     with hi.ConsoleCapture(label='[test_bad_container]'):
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
 
-        fun.bad_container.run().wait()
+#         fun.bad_container.run().wait()
 
-        with hi.Config(container=True):
-            x = fun.bad_container.run()
-            with pytest.raises(Exception):
-                x.wait()
+#         with hi.Config(container=True):
+#             x = fun.bad_container.run()
+#             with pytest.raises(Exception):
+#                 x.wait()
         
-        with hi.Config(job_handler=rjh, container=True):
-            x = fun.bad_container.run()
-            with pytest.raises(Exception):
-                x.wait()
+#         with hi.Config(job_handler=rjh, container=True):
+#             x = fun.bad_container.run()
+#             with pytest.raises(Exception):
+#                 x.wait()
 
-@pytest.mark.compute_resource
-def test_job_arg_error(general, compute_resource, mongodb, kachery):
-    import pytest
+# @pytest.mark.compute_resource
+# def test_job_arg_error(general, compute_resource, mongodb, kachery):
+#     import pytest
     
-    with hi.ConsoleCapture(label='[test_job_arg_error]'):
-        x = fun.intentional_error.run()
-        a = fun.do_nothing.run(x=x)
-        with pytest.raises(Exception):
-            a.wait()
+#     with hi.ConsoleCapture(label='[test_job_arg_error]'):
+#         x = fun.intentional_error.run()
+#         a = fun.do_nothing.run(x=x)
+#         with pytest.raises(Exception):
+#             a.wait()
 
-def test_wait(general):
-    pjh = hi.ParallelJobHandler(num_workers=4)
-    with hi.Config(job_handler=pjh):
-        a = fun.do_nothing.run(x=None, delay=0.2)
-        hi.wait(0.1)
-        hi.wait()
-        assert a.result() == None
+# def test_wait(general):
+#     pjh = hi.ParallelJobHandler(num_workers=4)
+#     with hi.Config(job_handler=pjh):
+#         a = fun.do_nothing.run(x=None, delay=0.2)
+#         hi.wait(0.1)
+#         hi.wait()
+#         assert a.result() == None
 
-def test_extras(general):
-    with hi.Config(container='docker://jupyter/scipy-notebook:678ada768ab1'):
-        a = fun.additional_file.run()
-        assert a.wait().array().shape == (2, 3)
+# def test_extras(general):
+#     with hi.Config(container='docker://jupyter/scipy-notebook:678ada768ab1'):
+#         a = fun.additional_file.run()
+#         assert a.wait().array().shape == (2, 3)
 
-        a = fun.local_module.run()
-        assert a.wait() == True
+#         a = fun.local_module.run()
+#         assert a.wait() == True
 
-@pytest.mark.compute_resource
-def test_missing_input_file(general, compute_resource, mongodb, kachery):
-    with hi.ConsoleCapture(label='[test_missing_input_file]'):
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
-        path = ka.store_text('test-text')
-        false_path = path.replace('0', '1')
-        assert path != false_path
+# @pytest.mark.compute_resource
+# def test_missing_input_file(general, compute_resource, mongodb, kachery):
+#     with hi.ConsoleCapture(label='[test_missing_input_file]'):
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+#         path = ka.store_text('test-text')
+#         false_path = path.replace('0', '1')
+#         assert path != false_path
 
-        with hi.Config(container=True):
-            a = fun.do_nothing.run(x=[dict(some_file=hi.File(path))]).set(label='do-nothing-1')
-            a.wait()
-            b = fun.do_nothing.run(x=[dict(some_file=hi.File(false_path))]).set(label='do-nothing-2')
-            with pytest.raises(Exception):
-                b.wait()
+#         with hi.Config(container=True):
+#             a = fun.do_nothing.run(x=[dict(some_file=hi.File(path))]).set(label='do-nothing-1')
+#             a.wait()
+#             b = fun.do_nothing.run(x=[dict(some_file=hi.File(false_path))]).set(label='do-nothing-2')
+#             with pytest.raises(Exception):
+#                 b.wait()
         
-        with hi.Config(job_handler=rjh, container=True):
-            a = fun.do_nothing.run(x=[dict(some_file=hi.File(path))]).set(label='do-nothing-remotely-1')
-            a.wait()
-            b = fun.do_nothing.run(x=[dict(some_file=hi.File(false_path))]).set(label='do-nothing-remotely-2')
-            with pytest.raises(Exception):
-                b.wait()
+#         with hi.Config(job_handler=rjh, container=True):
+#             a = fun.do_nothing.run(x=[dict(some_file=hi.File(path))]).set(label='do-nothing-remotely-1')
+#             a.wait()
+#             b = fun.do_nothing.run(x=[dict(some_file=hi.File(false_path))]).set(label='do-nothing-remotely-2')
+#             with pytest.raises(Exception):
+#                 b.wait()
 
-@pytest.mark.focus
-@pytest.mark.compute_resource
-def test_identity(general, compute_resource, mongodb, kachery):
-    with hi.ConsoleCapture(label='[test_identity]'):
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
-        path = ka.store_text('test-text-2')
+# @pytest.mark.focus
+# @pytest.mark.compute_resource
+# def test_identity(general, compute_resource, mongodb, kachery):
+#     with hi.ConsoleCapture(label='[test_identity]'):
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+#         path = ka.store_text('test-text-2')
 
-        with hi.Config(container=True):
-            a = ([dict(file=hi.File(path))],)
-            b = fun.identity.run(x=a).wait()
-            assert ka.get_file_hash(b[0][0]['file'].path) == ka.get_file_hash(path)
+#         with hi.Config(container=True):
+#             a = ([dict(file=hi.File(path))],)
+#             b = fun.identity.run(x=a).wait()
+#             assert ka.get_file_hash(b[0][0]['file'].path) == ka.get_file_hash(path)
         
-        with hi.Config(job_handler=rjh, container=True, download_results=True):
-            a = ([dict(file=hi.File(path))],)
-            b = fun.identity.run(x=a).wait()
-            assert ka.get_file_hash(b[0][0]['file'].path) == ka.get_file_hash(path)
+#         with hi.Config(job_handler=rjh, container=True, download_results=True):
+#             a = ([dict(file=hi.File(path))],)
+#             b = fun.identity.run(x=a).wait()
+#             assert ka.get_file_hash(b[0][0]['file'].path) == ka.get_file_hash(path)
 
-def test_slurm_job_handler(general, tmp_path):
-    slurm_working_dir = str(tmp_path / 'slurm-job-handler')
-    sjh = hi.SlurmJobHandler(
-        working_dir=slurm_working_dir,
-        use_slurm=False,
-        num_workers_per_batch=3,
-        num_cores_per_job=2,
-        time_limit_per_batch=2400,  # number of seconds or None
-        max_simultaneous_batches=5,
-        additional_srun_opts=[]
-    )
-    with hi.ConsoleCapture(label='[slurm_job_handler]'):
-        with hi.Config(container=True, job_handler=sjh):
-            shapes = [(j, 3) for j in range(1, 8)]
-            results = []
-            for shape in shapes:
-                f = fun.zeros(shape=shape, delay=0.1)
-                g = fun.add.run(x=f, y=1)
-                A = fun.identity.run(x=g)
-                results.append(A)
-            for i in range(len(shapes)):
-                assert shapes[i] == results[i].wait().array().shape
-                print(f'Checked: {shapes[i]} {results[i].wait().array().shape}')
+# def test_slurm_job_handler(general, tmp_path):
+#     slurm_working_dir = str(tmp_path / 'slurm-job-handler')
+#     sjh = hi.SlurmJobHandler(
+#         working_dir=slurm_working_dir,
+#         use_slurm=False,
+#         num_workers_per_batch=3,
+#         num_cores_per_job=2,
+#         time_limit_per_batch=2400,  # number of seconds or None
+#         max_simultaneous_batches=5,
+#         additional_srun_opts=[]
+#     )
+#     with hi.ConsoleCapture(label='[slurm_job_handler]'):
+#         with hi.Config(container=True, job_handler=sjh):
+#             shapes = [(j, 3) for j in range(1, 8)]
+#             results = []
+#             for shape in shapes:
+#                 f = fun.zeros(shape=shape, delay=0.1)
+#                 g = fun.add.run(x=f, y=1)
+#                 A = fun.identity.run(x=g)
+#                 results.append(A)
+#             for i in range(len(shapes)):
+#                 assert shapes[i] == results[i].wait().array().shape
+#                 print(f'Checked: {shapes[i]} {results[i].wait().array().shape}')
 
-@pytest.mark.compute_resource
-def test_combo_local_remote(general, compute_resource, mongodb, kachery):
-    with hi.ConsoleCapture(label='[test_combo_local_remote]'):
-        db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
-        rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+# @pytest.mark.compute_resource
+# def test_combo_local_remote(general, compute_resource, mongodb, kachery):
+#     with hi.ConsoleCapture(label='[test_combo_local_remote]'):
+#         db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+#         rjh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
         
-        A = np.ones((5, 5))
+#         A = np.ones((5, 5))
 
-        with hi.Config(container=True, job_handler=rjh):
-            with hi.Config(download_results=True):
-                B = fun.add.run(x=A, y=1)
-        b = B.wait().array()
-        assert np.allclose(A + 1, b)
+#         with hi.Config(container=True, job_handler=rjh):
+#             with hi.Config(download_results=True):
+#                 B = fun.add.run(x=A, y=1)
+#         b = B.wait().array()
+#         assert np.allclose(A + 1, b)
 
-# def test_spikeforest_remote_compute_resource(general, remote_compute_resource):
-def test_spikeforest_remote_compute_resource(general):
-    if not os.getenv('SPIKEFOREST_COMPUTE_RESOURCE_READWRITE_PASSWORD', None):
-        print('Skipping remote compute resource test because environment variable not set: SPIKEFOREST_COMPUTE_RESOURCE_READWRITE_PASSWORD')
-        return
+# # def test_spikeforest_remote_compute_resource(general, remote_compute_resource):
+# def test_spikeforest_remote_compute_resource(general):
+#     if not os.getenv('SPIKEFOREST_COMPUTE_RESOURCE_READWRITE_PASSWORD', None):
+#         print('Skipping remote compute resource test because environment variable not set: SPIKEFOREST_COMPUTE_RESOURCE_READWRITE_PASSWORD')
+#         return
 
-    db = hi.Database.preset('spikeforest_readwrite')
-    rjh = hi.RemoteJobHandler(database=db, compute_resource_id='spikeforest1')
-    with hi.Config(container=True, job_handler=rjh):
-        _run_pipeline()
+#     db = hi.Database.preset('spikeforest_readwrite')
+#     rjh = hi.RemoteJobHandler(database=db, compute_resource_id='spikeforest1')
+#     with hi.Config(container=True, job_handler=rjh):
+#         _run_pipeline()
 
-def test_preset_config(general):
-    db = hi.Database.preset('spikeforest_readonly')
-    assert db is not None
+# def test_preset_config(general):
+#     db = hi.Database.preset('spikeforest_readonly')
+#     assert db is not None
 
-def test_bin(general, tmp_path, mongodb, kachery):
-    working_dir = str(tmp_path / 'compute-resource')
-    os.mkdir(working_dir)
-    ss1 = hi.ShellScript(f"""
-    #!/bin/bash
-    set -ex
+# def test_bin(general, tmp_path, mongodb, kachery):
+#     working_dir = str(tmp_path / 'compute-resource')
+#     os.mkdir(working_dir)
+#     ss1 = hi.ShellScript(f"""
+#     #!/bin/bash
+#     set -ex
 
-    cd {working_dir}
-    hither-compute-resource init
-    """)
-    ss1.start()
-    ss1.wait()
-    config_fname = working_dir + '/compute_resource.json'
-    with open(config_fname, 'r') as f:
-        config = json.load(f)
-    config['compute_resource_id'] = 'test_resource_1'
-    database_config = dict(
-        mongo_url = f'mongodb://localhost:{MONGO_PORT}',
-        database='test_database'
-    )
-    config['database'] = database_config
-    config['kachery'] = KACHERY_CONFIG
-    with open(config_fname, 'w') as f:
-        json.dump(config, f)
-    ss2 = hi.ShellScript(f"""
-    #!/bin/bash
-    set -ex
+#     cd {working_dir}
+#     hither-compute-resource init
+#     """)
+#     ss1.start()
+#     ss1.wait()
+#     config_fname = working_dir + '/compute_resource.json'
+#     with open(config_fname, 'r') as f:
+#         config = json.load(f)
+#     config['compute_resource_id'] = 'test_resource_1'
+#     database_config = dict(
+#         mongo_url = f'mongodb://localhost:{MONGO_PORT}',
+#         database='test_database'
+#     )
+#     config['database'] = database_config
+#     config['kachery'] = KACHERY_CONFIG
+#     with open(config_fname, 'w') as f:
+#         json.dump(config, f)
+#     ss2 = hi.ShellScript(f"""
+#     #!/bin/bash
+#     set -ex
 
-    cd {working_dir}
-    hither-compute-resource start
-    """)
-    ss2.start()
-    ss2.wait(1)
+#     cd {working_dir}
+#     hither-compute-resource start
+#     """)
+#     ss2.start()
+#     ss2.wait(1)
 
-    db = hi.Database(**database_config)
-    rjh = hi.RemoteJobHandler(
-        database=db,
-        compute_resource_id='test_resource_1',
-    )
-    with hi.Config(container=True, job_handler=rjh):
-        _run_short_pipeline()
-        hi.wait()
-    ss2.kill()
+#     db = hi.Database(**database_config)
+#     rjh = hi.RemoteJobHandler(
+#         database=db,
+#         compute_resource_id='test_resource_1',
+#     )
+#     with hi.Config(container=True, job_handler=rjh):
+#         _run_short_pipeline()
+#         hi.wait()
+#     ss2.kill()


### PR DESCRIPTION
# Data-store access encapsulation

This PR comprises several changes to centralize accesses to the persistent data store which is used for job caching and remote-resource job coordination. The main affected files are `database.py`, which has grown to absorb a lot of the database access code, and the three consumers of the database class, `computeresource.py`, `remotejobhandler.py`, and `jobcache.py`. As part of this, bare string literals referring to field names in the serialized `Job` object and in other objects stored in MongoDb have been converted to constants, which I added to `_enums.py` (for want of a better location). We may wish to move all serialization code to live closer to these constants, but I've left that alone for now.

## Rationale

MongoDB is designed to store relatively free-form or flexibly-structured data in key-value/JSON format. As a result, database access logic is vulnerable to typos and to changes in field names and data structure. This is particularly the case when logic to access stored records is spread across multiple files or located at a remove from the file structure definitions. More generally, business-logic code is easier to follow if data-access code is encapsulated, so that a function whose purpose is to modify the state of data entities can operate at a uniform level of abstraction (without needing to digress into lower levels to deal with the mechanics of querying or updating a data store).

Encapsulating lower-level data access in a data access layer makes code more robust to both of these challenges.

## Major File Changes

### `_computeresource.py`

* Added type annotations
* All database queries and updates have been moved to `database.py` in descriptively named functions. There may still be some references to the structure of data within the serialized job store--i.e. some times when we still have to treat the result of queries like a dictionary and fetch particular fields by name--but these are largely reduced, and dictionary keys are all global constants rather than hard-coded values.
* Broke segments of main iteration loop into smaller functions
* Add coverage for complete set of possible job statuses to main iteration loop (note that I don't actually know whether some of these can occur or what we should do if they do!)
* Note that checking a job cache for a job doesn't guarantee a cache hit--is it possible that a job could have a `Finished` or `Error` status as-deserialized, even if it isn't found in the cache?

### `database.py`

* Added type hints
* Added methods to access different members according to business-logic rules described by descriptive method names (e.g. `_get_active_job_handler_ids`, `_clear_expired_job_handlers`, `_fetch_pending_jobs`, etc)
* All database access logic methods refer to descriptive constants instead of hard-coded string literals

### `jobcache.py`

* Reduced to two methods, with database access logic offloaded to `database.py`
* Clarified function name & logic of `check_job` method (now `fetch_cached_job_results`)

### `remotejobhandler.py`

* Again, database access code has been moved to the database class, with access and modification functions given  specific names suggesting the underlying logic
* *Some* type annotations (I'm deferring the complete look-through for this until a later PR)
* Broke main `iterate` loop into smaller functions & slight reordering of status-checking logic and logging


## Incidental File Changes

Quick explanation of the changes made to files not mentioned above.

### `_Config.py`

Minor changes related to type-checking and possible circular import statements. (My understanding is this situation will be improved in a future version of Python.)

### `_enums.py`

* Added classes `JobKeys`, `JobHandlerKeyrs`, `ComputeResourceKeys` which define fields stored in MongoDB or used in serialized versions of `Job` records.
*  The `JobKeys` class additionally defines a method to extract metadata from a serialized `Job` for remote compute resource use. (This could be moved elsewhere.) It also defines a quick check to ensure that a record returned from Mongo is actually a `Job` by verifying three fields which should be defined.
* Also added a convenience method to define the job statuses which are used locally (as opposed to the ones which are only supposed to exist as statuses on a remote compute resource).

### `_exceptions.py`

Attempt at making a collection of custom Exceptions for use in this tool. This idea has not been explored thoroughly yet.

### `job.py`

* Removed deprecated methods which have been superseded by content from previous merge
* Moved hashing internal to the `Job`, since that class already has all the needed dependencies; this centralizes it and let me get rid of an import in `jobcache.py`
* Changed serialization method to refer to field-name constants instead of hard-coded string literals


### `_jobmanager.py`

Call updated function name from `job_cache.fetch_cached_job_results` and remove extraneous comment.

### `_util.py`

Centralized the method that sets polling intervals in `computeresource.py` and `remotejobhandler.py`. If these need different interval schemes later on it can be popped back out easily enough.

### `tests/old_test_1.py`

I commented the whole thing out, though we should probably just delete it--it's legacy code at this point and git has it if we need it.