### PR TITLE
implementing job.cancel()

### DIFF
--- a/hither/__init__.py
+++ b/hither/__init__.py
@@ -5,6 +5,7 @@ from .core import reset
 from ._identity import identity
 from ._temporarydirectory import TemporaryDirectory
 from ._shellscript import ShellScript
+from ._exceptions import JobCancelledException
 from ._filelock import FileLock
 from ._consolecapture import ConsoleCapture
 from .core import _deserialize_job

--- a/hither/_enums.py
+++ b/hither/_enums.py
@@ -14,11 +14,10 @@ class JobStatus(Enum):
     QUEUED = 'queued'
     RUNNING = 'running'
     FINISHED = 'finished'
-    CANCELED = 'canceled' # remote-only status (for compute resource/Slurm/etc)
 
     @classmethod
     def complete_statuses(cls: Type['JobStatus']) -> List['JobStatus']:
-        return [JobStatus.ERROR, JobStatus.FINISHED, JobStatus.CANCELED]
+        return [JobStatus.ERROR, JobStatus.FINISHED]
 
     @classmethod
     def incomplete_statuses(cls: Type['JobStatus']) -> List['JobStatus']:
@@ -38,6 +37,7 @@ class HitherFileType(Enum):
     SERIALIZED_FILE = 'hither_file'
     
 class JobKeys:
+    CANCEL_REQUESTED = 'cancel_requested'
     CLIENT_CODE = 'client_code'
     CODE = 'code'
     COMPUTE_RESOURCE = 'compute_resource_id'

--- a/hither/_exceptions.py
+++ b/hither/_exceptions.py
@@ -1,2 +1,5 @@
 class DeserializationException(Exception):
     pass
+
+class JobCancelledException(Exception):
+    pass

--- a/hither/defaultjobhandler.py
+++ b/hither/defaultjobhandler.py
@@ -11,7 +11,7 @@ class DefaultJobHandler(BaseJobHandler):
         job._execute()
 
     def cancel_job(self, job_id):
-        print('Warning: not yet able to cancel job of defaultjobhandler')
+        print('Warning: not able to cancel job of defaultjobhandler')
 
     def iterate(self):
         pass

--- a/hither/job.py
+++ b/hither/job.py
@@ -212,6 +212,10 @@ class Job:
 
     def get_runtime_info(self): # NOTE: Unused
         return deepcopy(self._runtime_info)
+    
+    def cancel(self):
+        assert self._job_handler is not None, 'Cannot cancel a job that does not have a job handler'
+        self._job_handler.cancel_job(job_id=self._job_id)
 
     def _execute(self):
         if self._container is not None:

--- a/hither/paralleljobhandler.py
+++ b/hither/paralleljobhandler.py
@@ -8,6 +8,7 @@ import hither as hi
 
 from ._basejobhandler import BaseJobHandler
 from ._enums import JobStatus
+from ._exceptions import JobCancelledException
 
 class ParallelJobHandler(BaseJobHandler):
     def __init__(self, num_workers):
@@ -39,7 +40,7 @@ class ParallelJobHandler(BaseJobHandler):
                     pp.join()
                 p['job']._result = None
                 p['job']._status = JobStatus.ERROR
-                p['job']._exception = Exception('Job canceled')
+                p['job']._exception = JobCancelledException('Job canceled')
                 p['job']._runtime_info = None
                 p['pjh_status'] = JobStatus.ERROR
     

--- a/hither/paralleljobhandler.py
+++ b/hither/paralleljobhandler.py
@@ -34,10 +34,14 @@ class ParallelJobHandler(BaseJobHandler):
             if p['job']._job_id == job_id:
                 if p['pjh_status'] == JobStatus.RUNNING:
                     pp = p['process']
-                    print(f'Terminating process.')
+                    print(f'ParallelJobHandler: Terminating process.')
                     pp.terminate()
                     pp.join()
-                p['pjh_status'] = JobStatus.CANCELED
+                p['job']._result = None
+                p['job']._status = JobStatus.ERROR
+                p['job']._exception = Exception('Job canceled')
+                p['job']._runtime_info = None
+                p['pjh_status'] = JobStatus.ERROR
     
     def iterate(self):
         if self._halted:

--- a/hither/remotejobhandler.py
+++ b/hither/remotejobhandler.py
@@ -54,7 +54,14 @@ class RemoteJobHandler(BaseJobHandler):
         self._report_action()
     
     def cancel_job(self, job_id):
-        print('Warning: not yet able to cancel job of remotejobhandler')
+        if job_id not in self._jobs:
+            print(f'Warning: RemoteJobHandler -- cannot cancel job {job_id}. Job with this id not found.')
+            return
+        self._database.cancel_job(
+            compute_resource_id=self._compute_resource_id,
+            handler_id=self._handler_id,
+            job_id=job_id
+        )
     
     def iterate(self) -> None:
         elapsed_database_poll = time.time() - self._timestamp_database_poll

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ def pytest_addoption(parser):
                  default=False, help="enable container tests")
     parser.addoption('--remote', action='store_true', dest="remote",
                  default=False, help="enable remote tests")
+    parser.addoption('--current', action='store_true', dest="current",
+                 default=False, help="run only tests marked as current")
 
 def pytest_configure(config):
     config.addinivalue_line(
@@ -25,14 +27,20 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "remote: test runs jobs on remote server"
     )
+    config.addinivalue_line(
+        "markers", "current: for convenience -- mark one test as current"
+    )
 
     markexpr_list = []
-
-    if not config.option.container:
-        markexpr_list.append('not container')
     
-    if not config.option.remote:
-        markexpr_list.append('not remote')
+    if config.option.current:
+        markexpr_list.append('current')
+    else:
+        if not config.option.container:
+            markexpr_list.append('not container')
+        
+        if not config.option.remote:
+            markexpr_list.append('not remote')
     
     if len(markexpr_list) > 0:
         markexpr = ' and '.join(markexpr_list)

--- a/tests/functions/do_nothing.py
+++ b/tests/functions/do_nothing.py
@@ -3,7 +3,7 @@ import hither as hi
 
 @hi.function('do_nothing', '0.1.0')
 @hi.container('docker://jupyter/scipy-notebook:678ada768ab1')
-def do_nothing(x, delay=None):
+def do_nothing(x=None, delay=None):
     if delay is not None:
         time.sleep(delay)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,21 @@ def do_test_pipeline():
 def test_pipeline(general):
     do_test_pipeline()
 
+def test_cancel_job(general):
+    pjh = hi.ParallelJobHandler(num_workers=4)
+    ok = False
+    with hi.Config(job_handler=pjh):
+        a = fun.do_nothing.run(delay=20)
+        a.wait(0.1)
+        a.cancel()
+        try:
+            a.wait(10)
+        except:
+            print('Got the expected exception')
+            ok = True
+    if not ok:
+        raise Exception('Did not get the expected exception.')
+
 @pytest.mark.container
 def test_pipeline_in_container(general):
     with hi.Config(container=True):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -21,7 +21,7 @@ def test_cancel_job(general):
         a.cancel()
         try:
             a.wait(10)
-        except:
+        except hi.JobCancelledException:
             print('Got the expected exception')
             ok = True
     if not ok:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -64,3 +64,20 @@ def test_remote_4(general, mongodb, kachery_server, compute_resource):
     c = c.wait()
     assert np.array_equal(c, 2* np.ones((4, 3)))
     assert jh._internal_counts.num_jobs == 4, f'Unexpected number of jobs: {jh._internal_counts.num_jobs}'
+
+@pytest.mark.remote
+def test_remote_5(general, mongodb, kachery_server, compute_resource):
+    db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
+    jh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)
+    ok = False
+    with hi.Config(job_handler=jh, container=True, download_results=True):
+        a = fun.do_nothing.run(delay=20)
+        a.wait(0.1)
+        a.cancel()
+        try:
+            a.wait(10)
+        except:
+            print('Got the expected exception')
+            ok = True
+    if not ok:
+        raise Exception('Did not get the expected exception.')


### PR DESCRIPTION
Implementation of Job.cancel().

This tells the job handler to cancel the job. The job handler is then responsible for killing the job with an error.

In the case of ParallelJobHandler, this terminates the job process and sets the status to Error.

In the case of RemoteJobHandler, this writes a cancel_requested=True record on the database for the job. The job handler periodically checks for jobs flagged like this, and then cancels them by calling self._job_handler.cancel_job(job_id).

In the case of DefaultJobHandler... canceling is impossible, because jobs are synchronous. A warning is generated.

Canceling for SlurmJobHandler is not yet implemented.

Removed the JobStatus.CANCELED enum. Instead, ERROR status is used, and the exception string contains the information that the job was canceled.

Added a couple of new unit tests for the new functionality.