### PR TITLE
Container singleton

### DIFF
--- a/hither/_Config.py
+++ b/hither/_Config.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Deque, Dict, Union, TYPE_CHECKING
 from ._basejobhandler import BaseJobHandler
+from ._enums import ConfigKeys
 
 ## Construction to avoid circular imports at runtime when we just need to fix a type reference
 if TYPE_CHECKING:
@@ -54,20 +55,18 @@ class Config:
             self.new_config[k] = deepcopy(v) if isinstance(v, dict) else v
 
         # TODO: find a neater way to do this (kwargs?)
-        self.coalesce('container', container)
-        self.coalesce('job_handler', job_handler)
-        self.coalesce('job_cache', job_cache)
-        self.coalesce('download_results', download_results)
-        self.coalesce('job_timeout', job_timeout)
+        self.coalesce(ConfigKeys.CONTAINER, container)
+        self.coalesce(ConfigKeys.JOB_HANDLER, job_handler)
+        self.coalesce(ConfigKeys.JOB_CACHE, job_cache)
+        self.coalesce(ConfigKeys.DOWNLOAD_RESULTS, download_results)
+        self.coalesce(ConfigKeys.TIMEOUT, job_timeout)
 
 
     @staticmethod
     # TODO: python 3.8 gives better tools for typehinting dicts, revise this eventually
     def set_default_config(cfg: Dict[Any, Any]) -> None:
         # TODO: Add a guard against resetting default config when one already exists?
-        # There is probably a better way to handle the known-fields enumeration.
-        known_fields = ['container', 'job_handler', 'job_cache', 'download_results', 'job_timeout']
-        for k in known_fields:
+        for k in ConfigKeys.known_configuration_keys():
             if k not in cfg:
                 raise Exception(f"Proposed default configuration is missing a value for {k}")
             if cfg[k] == Inherit.INHERIT:
@@ -97,6 +96,7 @@ class Config:
 
     def coalesce(self, name: str, val: Any) -> None:
         if val == Inherit.INHERIT:
+            # On INHERIT, we return without making changes, keeping the value from
+            # the parent config. Then "None" can be used as an actual value.
             return
-        # This allows "None" to be passed as an actual value
         self.new_config[name] = val

--- a/hither/_containermanager.py
+++ b/hither/_containermanager.py
@@ -1,0 +1,109 @@
+import os
+import sys
+
+from ._enums import ConfigKeys
+from ._shellscript import ShellScript
+
+class ContainerManager:
+    """What 'container preparation' actually does is make sure that whatever container
+    configuration information has been attached to a Job's function `f` has been pulled
+    from a global container store (like dockerhub) and is available whenever the Job
+    wants to run, before it runs.
+    The value of f._hither_container is added in core.py if the `container` param is
+    passed, and should be something like a docker:// URL.
+    """
+    _prepared_docker_images = dict()
+    _prepared_singularity_containers = dict()
+
+    @staticmethod
+    def prepare_container(container:str) -> None:
+        """Add the specified container string to the relevant list of already-prepared
+        containers, and fetch the right kind of container image (docker or singularity)
+        based on environment variable configuration.
+
+        Arguments:
+            container {str} -- URL to container image (like 'docker://...') or other
+            string value that can be passed to 'docker pull' and 'docker run' (or
+            'singularity run ...')
+        """
+        if os.getenv(ConfigKeys.HITHER_USE_SINGULARITY_ENV, None) == 'TRUE':
+            if container not in ContainerManager._prepared_singularity_containers:
+                ContainerManager._do_prepare_singularity_container(container)
+                ContainerManager._prepared_singularity_containers[container] = True
+        else:
+            if os.getenv(ConfigKeys.HITHER_NO_DOCKER_PULL_ENV, None) != 'TRUE':
+                if container not in ContainerManager._prepared_docker_images:
+                    ContainerManager._do_pull_docker_image(container)
+                    ContainerManager._prepared_docker_images[container] = True
+
+    @staticmethod
+    def _do_prepare_singularity_container(container:str) -> None:
+        """Executes script to prepare container by calling 'singularity run ...'
+
+        Arguments:
+            container {str} -- string of arguments to be passed to 'singularity run'.
+
+        Raises:
+            Exception: Thrown if the shell script calling the singularity command
+            returns a non-zero (error) status code.
+        """
+        print(f'Building singularity container: {container}')
+        ss = ShellScript(f'''
+            #!/bin/bash
+
+            exec singularity run {container} echo "built {container}"
+        ''')
+        ss.start()
+        retcode = ss.wait()
+        if retcode != 0:
+            raise Exception(f'Problem building container {container}')
+
+    @staticmethod
+    def _do_pull_docker_image(container:str) -> None:
+        """Fetches Docker container images from the store per the URL in the
+        parameter.
+
+        Arguments:
+            container {str} -- URL for Docker image, optionally starting with
+            'docker://'. Passed to 'docker pull'.
+
+        Raises:
+            Exception: Raised if shell script calling 'docker pull' returns non-zero
+            (error) status code.
+        """
+        print(f'Pulling docker container: {container}')
+        container = ContainerManager._docker_form_of_container_string(container)
+        if (sys.platform == "win32"):
+            if 1: # pragma: no cover
+                ss = ShellScript(f'''
+                    docker pull {container}
+                ''')
+        else:
+            ss = ShellScript(f'''
+                #!/bin/bash
+                set -ex
+                
+                exec docker pull {container}
+            ''')
+        ss.start()
+        retcode = ss.wait()
+        if retcode != 0:
+            raise Exception(f'Problem pulling container {container}')
+
+    @staticmethod
+    def _docker_form_of_container_string(container:str) -> str:
+        """Strips leading 'docker://' from string.
+
+        Arguments:
+            container {str} -- URL for Docker image.
+
+        Returns:
+            str -- input, without leading 'docker://'
+        """
+        if container.startswith('docker://'):
+            return container[len('docker://'):]
+        else:
+            return container
+
+
+

--- a/hither/_enums.py
+++ b/hither/_enums.py
@@ -49,6 +49,9 @@ class JobKeys:
     FUNCTION = 'function'
     FUNCTION_NAME = 'function_name'
     FUNCTION_VERSION = 'function_version'
+    HITHER_ADDITIONAL_FILES = '_hither_additional_files'
+    HITHER_CONTAINER = '_hither_container'
+    HITHER_LOCAL_MODULES = '_hither_local_modules'
     JOB_HASH = 'hash'
     JOB_ID = 'job_id'
     JOB_TIMEOUT = 'job_timeout'
@@ -116,3 +119,8 @@ class ComputeResourceKeys:
     COMPUTE_RESOURCE = JobKeys.COMPUTE_RESOURCE # alias, since these should have same value
     KACHERY = 'kachery'
     UTCTIME = 'utctime'
+
+class ConfigKeys:
+    HITHER_DEBUG_ENV = 'HITHER_DEBUG'
+    HITHER_USE_SINGULARITY_ENV = 'HITHER_USE_SINGULARITY'
+    HITHER_NO_DOCKER_PULL_ENV = 'HITHER_DO_NOT_PULL_DOCKER_IMAGES'

--- a/hither/_enums.py
+++ b/hither/_enums.py
@@ -121,6 +121,18 @@ class ComputeResourceKeys:
     UTCTIME = 'utctime'
 
 class ConfigKeys:
+    ## Environment variables
     HITHER_DEBUG_ENV = 'HITHER_DEBUG'
     HITHER_USE_SINGULARITY_ENV = 'HITHER_USE_SINGULARITY'
     HITHER_NO_DOCKER_PULL_ENV = 'HITHER_DO_NOT_PULL_DOCKER_IMAGES'
+    ## Keys for the configuration dictionary
+    CONTAINER = 'container'
+    JOB_HANDLER = 'job_handler'
+    JOB_CACHE = 'job_cache'
+    DOWNLOAD_RESULTS = 'download_results'
+    TIMEOUT = 'job_timeout'
+
+    @staticmethod
+    def known_configuration_keys() -> List[str]:
+        return [ConfigKeys.CONTAINER, ConfigKeys.JOB_HANDLER, ConfigKeys.JOB_CACHE,
+                ConfigKeys.DOWNLOAD_RESULTS, ConfigKeys.TIMEOUT]

--- a/hither/_util.py
+++ b/hither/_util.py
@@ -5,7 +5,7 @@ import random
 from ._enums import HitherFileType
 from .file import File
 
-def _serialize_item(x, require_jsonable=True):
+def _serialize_item(x:Any, require_jsonable:bool=True) -> Any:
     if isinstance(x, File):
         return x.serialize()
     # TODO: move these cases where they belong
@@ -39,7 +39,7 @@ def _serialize_item(x, require_jsonable=True):
     else:
         return x
 
-def _is_jsonable(x):
+def _is_jsonable(x:Any) -> bool:
     import json
     try:
         json.dumps(x)
@@ -47,7 +47,7 @@ def _is_jsonable(x):
     except:
         return False
 
-def _deserialize_item(x):
+def _deserialize_item(x:Any) -> Any:
     if type(x) == dict:
         if '_type' in x and x['_type'] == 'tuple':
             return _deserialize_item(tuple(x['data']))
@@ -78,15 +78,9 @@ def _deserialize_item(x):
 #     f = io.BytesIO(bytes0)
 #     return np.load(f)
 
-def _utctime():
+def _utctime() -> float:
     from datetime import datetime, timezone
     return datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
-
-def _docker_form_of_container_string(container):
-    if container.startswith('docker://'):
-        return container[len('docker://'):]
-    else:
-        return container
 
 # NOTE: This can be centralized presently; used identically in computeresource and remotejobhandler.
 # If those ever need different polling interval setups, or if use broadens and we need something
@@ -102,7 +96,7 @@ def _get_poll_interval(last_timestamp: float) -> float:
     else:
         return 6
 
-def _random_string(num: int):
+def _random_string(num: int) -> str:
     """Generate random string of a given length.
     """
     return ''.join(random.choices('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', k=num))

--- a/hither/core.py
+++ b/hither/core.py
@@ -4,7 +4,7 @@ import os
 
 from ._Config import Config
 from .defaultjobhandler import DefaultJobHandler
-from ._enums import JobKeys
+from ._enums import ConfigKeys, JobKeys
 from .job import Job
 from ._jobmanager import _JobManager
 
@@ -75,27 +75,23 @@ def function(name, version):
             _global_registered_functions_by_name[name] = f
         
         def run(**arguments_for_wrapped_function):
-            configured_container = Config.get_current_config_value('container')
+            configured_container = Config.get_current_config_value(ConfigKeys.CONTAINER)
             if configured_container is True:
-                container = getattr(f, '_hither_container', None)
+                container = getattr(f, JobKeys.HITHER_CONTAINER, None)
             elif configured_container is not None and configured_container is not False:
                 container = configured_container
             else:
                 container=None
-            job_handler = Config.get_current_config_value('job_handler')
-            job_cache = Config.get_current_config_value('job_cache')
+            job_handler = Config.get_current_config_value(ConfigKeys.JOB_HANDLER)
+            job_cache = Config.get_current_config_value(ConfigKeys.JOB_CACHE)
             if job_handler is None:
                 job_handler = _global_job_handler
-            download_results = Config.get_current_config_value('download_results')
+            download_results = Config.get_current_config_value(ConfigKeys.DOWNLOAD_RESULTS)
             if download_results is None:
                 download_results = False
-            job_timeout = Config.get_current_config_value('job_timeout')
+            job_timeout = Config.get_current_config_value(ConfigKeys.TIMEOUT)
             label = name
             no_resolve_input_files = getattr(f, JobKeys.NO_RESOLVE_INPUT_FILES, False)
-            # if hasattr(f, '_no_resolve_input_files'):
-            #     no_resolve_input_files = f._no_resolve_input_files
-            # else:
-            #     no_resolve_input_files = False
             job = Job(f=f, wrapped_function_arguments=arguments_for_wrapped_function,
                       job_manager=_global_job_manager, job_handler=job_handler, job_cache=job_cache,
                       container=container, label=label, download_results=download_results,

--- a/hither/job.py
+++ b/hither/job.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import time
-from typing import Container, Dict, List, Union, Any, Optional
+from typing import List, Union, Any, Optional
 
 import kachery as ka
 from ._Config import Config

--- a/hither/job.py
+++ b/hither/job.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
 import time
-from typing import Dict, List, Union, Any, Optional
+from typing import Container, Dict, List, Union, Any, Optional
 
 import kachery as ka
 from ._Config import Config
 from ._consolecapture import ConsoleCapture
+from ._containermanager import ContainerManager
 from ._enums import JobStatus, JobKeys
 from ._exceptions import JobCancelledException
 from .file import File
@@ -188,19 +189,11 @@ class Job:
         _copy_structure_with_changes(self._wrapped_function_arguments, self.ensure_job_results_available_locally,
                                     _type = Job, _as_side_effect = False)
 
-    def result(self):
-        # To deprecate
-        return self.get_result()
-
     def get_result(self):
         if self._status == JobStatus.FINISHED:
             return self._result
         raise Exception('Cannot get result of job that is not yet finished.')
 
-    def exception(self):
-        # To deprecate
-        return self.get_exception()
-    
     def get_exception(self):
         if self._status == JobStatus.ERROR:
             assert self._exception is not None
@@ -310,7 +303,7 @@ class Job:
     def resolve_wrapped_job_values(self) -> None:
         self._wrapped_function_arguments = \
             _copy_structure_with_changes(self._wrapped_function_arguments,
-                lambda arg: arg.result(), _type = Job, _as_side_effect = False)
+                lambda arg: arg.get_result(), _type = Job, _as_side_effect = False)
 
 
     def is_ready_to_run(self) -> bool:
@@ -357,18 +350,20 @@ class Job:
         self._status = JobStatus.ERROR
         self._exception = Exception(f'Exception in wrapped Job: {str(errored_jobs[0]._exception)}')
 
-    def container_may_be_needed(self) -> bool:
-        """Returns whether this Job needs to have a container built before it can be run.
-
-        Returns:
-            bool -- Whether this Job requires a container to be built before it can be run.
+    def prepare_container_if_needed(self) -> None:
+        """Calls global container manager to ensure container images are downloaded, if a container is
+        required for the Job. On container fetch error, set error status and record the exception in the Job.
         """
-        if self._container is None: return False
-        if self._job_handler.is_remote: return False
-        # NOTE: We can't check whether the container is built or not, since we don't have
-        # visibility into those. If and when we have a globally-visible container store, then
-        # we could properly check that for it.
-        return True
+        # No need to prepare a container if none was specified
+        if self._container is None: return
+        # If we are attached to a remote job handler, the container is actually needed on the
+        # remote resource, not the machine where we're currently executing. Don't prepare anything.
+        if self._job_handler is not None and self._job_handler.is_remote: return
+        try:
+            ContainerManager.prepare_container(self._container)
+        except:
+            self._status = JobStatus.ERROR
+            self._exception = Exception(f"Unable to prepare container for Job {self._label}: {self._container}")
 
     def _compute_hash(self) -> str:
         hash_object = {
@@ -391,8 +386,8 @@ class Job:
                 code = self._code
             else:
                 assert self._f is not None, 'Cannot serialize function with generate_code=True when function and code are both not available'
-                additional_files = getattr(self._f, '_hither_additional_files', [])
-                local_modules = getattr(self._f, '_hither_local_modules', [])
+                additional_files = getattr(self._f, JobKeys.HITHER_ADDITIONAL_FILES, [])
+                local_modules = getattr(self._f, JobKeys.HITHER_LOCAL_MODULES, [])
                 code = _generate_source_code_for_function(self._f, name=function_name, additional_files=additional_files, local_modules=local_modules)
             function = None
         else:

--- a/hither/slurmjobhandler.py
+++ b/hither/slurmjobhandler.py
@@ -1,19 +1,20 @@
+import json
 import os
+import random
+import shutil
+import signal
 from sys import version
 import time
-import random
-import signal
-import shutil
 import traceback
-from ._basejobhandler import BaseJobHandler
-from ._shellscript import ShellScript
-from ._util import _random_string
-from ._filelock import FileLock
-from ._enums import JobStatus
 from typing import Optional, List, Union
-import json
-from .core import Job, _deserialize_item
 from os import rename
+
+from ._basejobhandler import BaseJobHandler
+from ._enums import JobStatus
+from ._filelock import FileLock
+from .job import Job
+from ._shellscript import ShellScript
+from ._util import _random_string, _deserialize_item
 
 DEFAULT_JOB_TIMEOUT = 1200
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,18 +14,17 @@ def test_pipeline(general):
 
 def do_test_cancel_job(*, container):
     pjh = hi.ParallelJobHandler(num_workers=4)
-    ok = False
     with hi.Config(job_handler=pjh, container=container):
-        a = fun.do_nothing.run(delay=10)
-        a.wait(0.3)
-        a.cancel()
         try:
-            a.wait(4)
+            a = fun.do_nothing.run(delay=20)
+            a.wait(1)
+            a.cancel()
+            # NOTE: If this wait time is too short, the job may resolve before it picks up the
+            # cancellation. In that event the test may fail for the wrong reasons.
+            a.wait(40)
+            assert False, "Call to cancelled Job succeeded but should have failed."
         except hi.JobCancelledException:
             print('Got the expected exception')
-            ok = True
-    if not ok:
-        raise Exception('Did not get the expected exception.')
 
 @pytest.mark.current
 def test_cancel_job(general):


### PR DESCRIPTION
This PR makes 2 changes, both pretty mechanical.

## Container Singleton

I pulled the container-repository management code out of `JobManager` and put it into a new `ContainerManager` class. This class works as a singleton; it keeps a dictionary of saved container configurations as a class variable (so, global) which can be accessed by name anywhere it's `import`ed. The advantage of doing this is that it removes the need to run accesses to the list of configured containers through a `JobManager`, which means we can move container setup right to the `Job` itself. Pretty minor change, but it makes things a tiny bit neater.

## ConfigKeys

I added a class to `_enums.py` to track the strings used for keys in the `Configuration` class, following the pattern used for Jobs and whatnot.

I also deleted a few stray bits of no-longer-used code and may have alphabetized the imports in one file.