### PR TITLE
graceful job cancelation for paralleljobhandler and run in container

### DIFF
--- a/hither/_enums.py
+++ b/hither/_enums.py
@@ -38,6 +38,7 @@ class HitherFileType(Enum):
     
 class JobKeys:
     CANCEL_REQUESTED = 'cancel_requested'
+    CANCELLED_FLAG = '::cancelled::'
     CLIENT_CODE = 'client_code'
     CODE = 'code'
     COMPUTE_RESOURCE = 'compute_resource_id'
@@ -60,6 +61,7 @@ class JobKeys:
     RUNTIME_INFO = 'runtime_info'
     SERIALIZATION = 'job_serialized'
     STATUS = 'status'
+    TIMED_OUT = 'Timed out'
     WRAPPED_ARGS = 'kwargs' # TODO CHANGE ME ONCE ALL REFERENCES ARE CENTRALIZED
 
     @staticmethod

--- a/hither/_run_serialized_job_in_container.py
+++ b/hither/_run_serialized_job_in_container.py
@@ -4,9 +4,10 @@ from typing import Any, List, Tuple, Union, Dict
 import json
 import shutil
 import time
+
+from ._enums import JobKeys
 from ._temporarydirectory import TemporaryDirectory
 from ._shellscript import ShellScript
-import kachery as ka
 from ._util import _docker_form_of_container_string, _random_string
 from ._util import _deserialize_item, _serialize_item
 
@@ -266,14 +267,14 @@ def _run_serialized_job_in_container(job_serialized, cancel_filepath: Union[str,
                 timed_out=True
             )
             success=False,
-            error='Timed out'
+            error=JobKeys.TIMED_OUT
             retval = -1
         elif did_cancel:
             runtime_info = dict(
                 cancelled=True
             )
             success=False
-            error='::cancelled::'
+            error=JobKeys.CANCELLED_FLAG
             retval = -1
         else:
             if (retcode != 0):

--- a/hither/job.py
+++ b/hither/job.py
@@ -4,13 +4,13 @@ from typing import Dict, List, Union, Any, Optional
 
 import kachery as ka
 from ._Config import Config
+from ._consolecapture import ConsoleCapture
 from ._enums import JobStatus, JobKeys
+from ._exceptions import JobCancelledException
 from .file import File
 from ._generate_source_code_for_function import _generate_source_code_for_function
 from ._run_serialized_job_in_container import _run_serialized_job_in_container
 from ._util import _random_string, _deserialize_item, _serialize_item, _flatten_nested_collection, _copy_structure_with_changes
-from ._exceptions import JobCancelledException
-from ._consolecapture import ConsoleCapture
 
 class Job:
     def __init__(self, *, f, wrapped_function_arguments,
@@ -229,7 +229,7 @@ class Job:
             else:
                 assert error is not None
                 assert error != 'None'
-                if error == '::cancelled::':
+                if error == JobKeys.CANCELLED_FLAG:
                     self._exception = JobCancelledException('Job was cancelled')
                 else:
                     self._exception = Exception(error)

--- a/hither/job.py
+++ b/hither/job.py
@@ -10,7 +10,7 @@ from ._generate_source_code_for_function import _generate_source_code_for_functi
 from ._run_serialized_job_in_container import _run_serialized_job_in_container
 from ._util import _random_string, _deserialize_item, _serialize_item, _flatten_nested_collection, _copy_structure_with_changes
 from ._exceptions import JobCancelledException
-
+from ._consolecapture import ConsoleCapture
 
 class Job:
     def __init__(self, *, f, wrapped_function_arguments,
@@ -239,7 +239,9 @@ class Job:
             try:
                 if not self._no_resolve_input_files:
                     self.resolve_files_in_wrapped_arguments()
-                ret = self._f(**self._wrapped_function_arguments)
+                with ConsoleCapture(label=self.get_label(), show_console=True) as cc:
+                    ret = self._f(**self._wrapped_function_arguments)
+                self._runtime_info = cc.runtime_info()
                 self._result = _copy_structure_with_changes(ret, File.kache_numpy_array, _as_side_effect=False)
                 # self._result = _deserialize_item(_serialize_item(ret))
                 self._status = JobStatus.FINISHED

--- a/hither/job.py
+++ b/hither/job.py
@@ -218,6 +218,7 @@ class Job:
         self._job_handler.cancel_job(job_id=self._job_id)
 
     def _execute(self, cancel_filepath=None):
+        # Note that cancel_filepath will only have an effect if we are running this in a container
         if self._container is not None:
             job_serialized = self._serialize(generate_code=True)
             success, result, runtime_info, error = _run_serialized_job_in_container(job_serialized, cancel_filepath=cancel_filepath)

--- a/hither/paralleljobhandler.py
+++ b/hither/paralleljobhandler.py
@@ -1,3 +1,6 @@
+import os
+import signal
+import tempfile
 from typing import List, Dict, Any
 import time
 import multiprocessing
@@ -22,7 +25,8 @@ class ParallelJobHandler(BaseJobHandler):
         import kachery as ka
         pipe_to_parent, pipe_to_child = multiprocessing.Pipe()
         serialized_job = job._serialize(generate_code=(job._container is not None))
-        process = multiprocessing.Process(target=_pjh_run_job, args=(pipe_to_parent, serialized_job, ka.get_config()))
+        cancel_filepath = f'{tempfile.gettempdir()}/pjh_cancel_job_{job._job_id}.txt'
+        process = multiprocessing.Process(target=_pjh_run_job, args=(pipe_to_parent, cancel_filepath, serialized_job, ka.get_config()))
         self._processes.append(dict(
             job=job,
             process=process,
@@ -35,14 +39,25 @@ class ParallelJobHandler(BaseJobHandler):
             if p['job']._job_id == job_id:
                 if p['pjh_status'] == JobStatus.RUNNING:
                     pp = p['process']
-                    print(f'ParallelJobHandler: Terminating process.')
-                    pp.terminate()
-                    pp.join()
-                p['job']._result = None
-                p['job']._status = JobStatus.ERROR
-                p['job']._exception = JobCancelledException('Job canceled')
-                p['job']._runtime_info = None
-                p['pjh_status'] = JobStatus.ERROR
+                    # pp.terminate()
+                    print(f'ParallelJobHandler: Stopping process.')
+                    cancel_filepath = f'{tempfile.gettempdir()}/pjh_cancel_job_{job_id}.txt'
+                    with open(cancel_filepath + '.tmp', 'w') as f:
+                        f.write('cancel.')
+                    os.rename(cancel_filepath+'.tmp', cancel_filepath)
+                    # pp.join()
+
+                    # if pp.is_alive():
+                    #     print('--- x2')
+                    #     pp.join(timeout=2)
+                    #     print('--- x3')
+                    # print(f'ParallelJobHandler: Process stopped.')
+                else:
+                    p['job']._result = None
+                    p['job']._status = JobStatus.ERROR
+                    p['job']._exception = JobCancelledException('Job cancelled')
+                    p['job']._runtime_info = None
+                    p['pjh_status'] = JobStatus.ERROR
     
     def iterate(self):
         if self._halted:
@@ -74,11 +89,11 @@ class ParallelJobHandler(BaseJobHandler):
         
         time.sleep(0.02)
 
-def _pjh_run_job(pipe_to_parent: Connection, serialized_job: Any, kachery_config: dict) -> None:
+def _pjh_run_job(pipe_to_parent: Connection, cancel_filepath: str, serialized_job: Any, kachery_config: dict) -> None:
     import kachery as ka
     ka.set_config(**kachery_config)
     job = hi._deserialize_job(serialized_job)
-    job._execute()
+    job._execute(cancel_filepath=cancel_filepath)
     ret = dict(
         result=job._result,
         status=job._status,

--- a/hither/paralleljobhandler.py
+++ b/hither/paralleljobhandler.py
@@ -66,6 +66,7 @@ class ParallelJobHandler(BaseJobHandler):
                     #     print('--- x3')
                     # print(f'ParallelJobHandler: Process stopped.')
                 else:
+                    # TODO: Consider if existing ERROR or FINISHED status should change this behavior 
                     p['job']._result = None
                     p['job']._status = JobStatus.ERROR
                     p['job']._exception = JobCancelledException('Job cancelled')

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,13 +12,12 @@ def do_test_pipeline():
 def test_pipeline(general):
     do_test_pipeline()
 
-@pytest.mark.current
-def test_cancel_job(general):
+def do_test_cancel_job(*, container):
     pjh = hi.ParallelJobHandler(num_workers=4)
     ok = False
-    with hi.Config(job_handler=pjh, container=True):
-        a = fun.do_nothing.run(delay=6)
-        a.wait(0.1)
+    with hi.Config(job_handler=pjh, container=container):
+        a = fun.do_nothing.run(delay=10)
+        a.wait(0.3)
         a.cancel()
         try:
             a.wait(4)
@@ -27,6 +26,14 @@ def test_cancel_job(general):
             ok = True
     if not ok:
         raise Exception('Did not get the expected exception.')
+
+@pytest.mark.current
+def test_cancel_job(general):
+    do_test_cancel_job(container=False)
+
+@pytest.mark.current
+def test_cancel_job_in_container(general):
+    do_test_cancel_job(container=True)
 
 @pytest.mark.container
 def test_pipeline_in_container(general):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,15 +12,16 @@ def do_test_pipeline():
 def test_pipeline(general):
     do_test_pipeline()
 
+@pytest.mark.current
 def test_cancel_job(general):
     pjh = hi.ParallelJobHandler(num_workers=4)
     ok = False
-    with hi.Config(job_handler=pjh):
-        a = fun.do_nothing.run(delay=20)
+    with hi.Config(job_handler=pjh, container=True):
+        a = fun.do_nothing.run(delay=6)
         a.wait(0.1)
         a.cancel()
         try:
-            a.wait(10)
+            a.wait(4)
         except hi.JobCancelledException:
             print('Got the expected exception')
             ok = True


### PR DESCRIPTION
Canceling jobs is a delicate and subtle matter, just as is the spelling of cancelled and cancelling. This is not the final solution, but I was able to improve the cancelation of containerized jobs by avoiding the use of Process.terminate() through use of a temporary cancellation file. The case of non-containerized jobs is handled differently -- via .terminate() and manually setting the status of the job to error.