### PR TITLE
Fix test instability when using a cancel file to shut down a container job.

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,18 +14,17 @@ def test_pipeline(general):
 
 def do_test_cancel_job(*, container):
     pjh = hi.ParallelJobHandler(num_workers=4)
-    ok = False
     with hi.Config(job_handler=pjh, container=container):
-        a = fun.do_nothing.run(delay=10)
-        a.wait(0.3)
-        a.cancel()
         try:
-            a.wait(4)
+            a = fun.do_nothing.run(delay=20)
+            a.wait(1)
+            a.cancel()
+            # NOTE: If this wait time is too short, the job may resolve before it picks up the
+            # cancellation. In that event the test may fail for the wrong reasons.
+            a.wait(40)
+            assert False, "Call to cancelled Job succeeded but should have failed."
         except hi.JobCancelledException:
             print('Got the expected exception')
-            ok = True
-    if not ok:
-        raise Exception('Did not get the expected exception.')
 
 @pytest.mark.current
 def test_cancel_job(general):


### PR DESCRIPTION
Five-liner. I realized after the last PR that one of the tests was failing; eventually tracked this down to a call to `Job.wait()` that was actually completing before the runner noticed the cancellation request, so I increased the timeout parameter. I also made some slight changes to the organization of the test during the course of trying to diagnose it (I thought originally that it was getting a different error, then added a specific assert for inappropriate success to confirm what was happening).