### PR TITLE
Couple reorg suggestions for issue 42.

### DIFF
--- a/hither/_Config.py
+++ b/hither/_Config.py
@@ -62,16 +62,6 @@ class Config:
         self.coalesce(ConfigKeys.DOWNLOAD_RESULTS, download_results)
         self.coalesce(ConfigKeys.TIMEOUT, job_timeout)
 
-        if job_handler is not None:
-            if not hasattr(job_handler, '_internal_counts'):
-                setattr(job_handler, '_internal_counts', SimpleNamespace(
-                    num_jobs=0,
-                    num_run_jobs=0,
-                    num_finished_jobs=0,
-                    num_errored_jobs=0,
-                    num_skipped_jobs=0
-                ))
-
     @staticmethod
     # TODO: python 3.8 gives better tools for typehinting dicts, revise this eventually
     def set_default_config(cfg: Dict[Any, Any]) -> None:

--- a/hither/_basejobhandler.py
+++ b/hither/_basejobhandler.py
@@ -1,10 +1,17 @@
 from abc import ABC, abstractmethod
+from types import SimpleNamespace
 
 from ._enums import JobStatus
 
 class BaseJobHandler(ABC):
     def __init__(self):
-        pass
+        self._internal_counts = SimpleNamespace(
+            num_jobs = 0,
+            num_run_jobs = 0,
+            num_finished_jobs = 0,
+            num_errored_jobs = 0,
+            num_skipped_jobs = 0
+        )
 
     @abstractmethod
     def handle_job(self, job):

--- a/hither/core.py
+++ b/hither/core.py
@@ -106,14 +106,6 @@ def function(name, version):
     
 
 _global_job_handler = DefaultJobHandler()
-# TODO: the following code is duplicated -- see config.py
-setattr(_global_job_handler, '_internal_counts', SimpleNamespace(
-    num_jobs=0,
-    num_run_jobs=0,
-    num_finished_jobs=0,
-    num_errored_jobs=0,
-    num_skipped_jobs=0
-))
 
 
 # TODO: Would be nice to avoid needing this

--- a/hither/database.py
+++ b/hither/database.py
@@ -127,13 +127,7 @@ class Database:
     # TODO: Job is, of course, obviously a Job, but typing it right now would lead to circular imports
     def _cache_job_result(self, job_hash: str, job:Any) -> None:
         query = { JobKeys.JOB_HASH: job_hash }
-        update_query = self._make_update({
-            JobKeys.JOB_HASH: job_hash,
-            JobKeys.STATUS: job._status.value,
-            JobKeys.RESULT: job._serialized_result(),
-            JobKeys.RUNTIME_INFO: job._runtime_info,
-            JobKeys.EXCEPTION: '{}'.format(job._exception)
-        })
+        update_query = self._make_update(job._as_cached_result())
         self._cached_job_results().update_one(query, update_query, upsert=True)
 
   ##### Job processing interface ###############

--- a/hither/defaultjobhandler.py
+++ b/hither/defaultjobhandler.py
@@ -3,6 +3,7 @@ from ._enums import JobStatus
 
 class DefaultJobHandler(BaseJobHandler):
     def __init__(self):
+        super().__init__()
         self.is_remote = False
 
     def handle_job(self, job):

--- a/hither/job.py
+++ b/hither/job.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import time
-from typing import List, Union, Any, Optional
+from typing import List, Dict, Union, Any, Optional
 
 import kachery as ka
 from ._Config import Config
@@ -371,6 +371,16 @@ class Job:
         if self._no_resolve_input_files:
             hash_object[JobKeys.NO_RESOLVE_INPUT_FILES] = True
         return ka.get_object_hash(hash_object)
+
+    def _as_cached_result(self) -> Dict[str, Any]:
+        cached_result = {
+            JobKeys.JOB_HASH: self._compute_hash(),
+            JobKeys.STATUS: self._status.value,
+            JobKeys.RESULT: self._serialized_result(),
+            JobKeys.RUNTIME_INFO: self._runtime_info,
+            JobKeys.EXCEPTION: '{}'.format(self._exception)
+        }
+        return cached_result
     
     def _serialized_result(self) -> Any:
         return _serialize_item(self._result)

--- a/hither/jobcache.py
+++ b/hither/jobcache.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union, Any
+from typing import Dict, List, Union, Any, Optional
 import tempfile
 import os
 import json
@@ -31,35 +31,28 @@ class JobCache:
             rerun_failing {bool} -- Whether to rerun jobs that had previously failed and been cached (default: {False})
             force_run {bool} -- Whether to force run jobs, even if results had previously been ached (default: {False})
         """
-        self._database = database
-        self._path = path
-        self._use_tempdir = use_tempdir
         self._cache_failing = cache_failing
         self._rerun_failing = rerun_failing
         self._force_run = force_run
         
+        set_parameters = 0
         errmsg = "You must provide exactly one of: database, use_tempdir, path"
-        if self._database is not None:
-            assert self._path is None, errmsg
-            assert self._use_tempdir is None, errmsg
-        
-        if self._path is not None:
-            assert self._database is None, errmsg
-            assert self._use_tempdir is None, errmsg
-        
-        if self._use_tempdir is not None:
-            assert self._database is None, errmsg
-            assert self._path is None, errmsg
-            self._path = f'{tempfile.gettempdir()}/hither_job_cache'
-            if not os.path.exists(self._path):
-                os.makedirs(self._path)
-        
-        if self._path:
-            self._disk_cache = DiskJobCache(self._path)
+        for param in [database, path, use_tempdir]:
+            if param is None: continue
+            set_parameters += 1
+        assert set_parameters == 1, errmsg
+
+        if database is not None:
+            self._cache_provider = DatabaseJobCache(database)
         else:
-            self._disk_cache = None
-        
-        assert self._database is not None or self._disk_cache is not None, errmsg
+            if path is None:
+                path = f'{tempfile.gettempdir()}/hither_job_cache'
+            if not os.path.exists(path):
+                # Query: do we want to create a specified path, too, if it doesn't exist?
+                # probably, right?
+                os.makedirs(path)
+            self._cache_provider = DiskJobCache(path)
+        assert self._cache_provider is not None, errmsg
 
     def fetch_cached_job_results(self, job: Job) -> bool:
         """Replaces completed Jobs with their result from cache, and returns whether the cache
@@ -107,39 +100,23 @@ class JobCache:
         if job._status == JobStatus.ERROR and not self._cache_failing:
             return 
         job_hash = job._compute_hash()
-        if self._database is not None:
-            self._database._cache_job_result(job_hash, job)
-        elif self._disk_cache is not None:
-            self._disk_cache._cache_job_result(job_hash, job)
-        else:
-            raise Exception('Unexpected error.')
+        self._cache_provider._cache_job_result(job_hash, job)
     
     def _fetch_cached_job_result(self, job_hash) -> Union[Dict[str, Any], None]:
-        if self._database is not None:
-            return self._database._fetch_cached_job_result(job_hash)
-        elif self._path is not None:
-            return self._disk_cache._fetch_cached_job_result(job_hash)
-        else:
-            raise Exception('Unexpected error.')
+        return self._cache_provider._fetch_cached_job_result(job_hash)
 
 class DiskJobCache:
     def __init__(self, path):
         self._path = path
     
-    def _cache_job_result(self, job_hash, job):
-        obj = {
-            JobKeys.JOB_HASH: job_hash,
-            JobKeys.STATUS: job._status.value,
-            JobKeys.RESULT: job._serialized_result(),
-            JobKeys.RUNTIME_INFO: job._runtime_info,
-            JobKeys.EXCEPTION: '{}'.format(job._exception)
-        }
+    def _cache_job_result(self, job_hash: str, job:Job):
+        obj = job._as_cached_result()
         p = self._get_cache_file_path(job_hash=job_hash, create_dir_if_needed=True)
         with FileLock(p + '.lock', exclusive=True):
             with open(p, 'w') as f:
                 json.dump(obj, f)
 
-    def _fetch_cached_job_result(self, job_hash):
+    def _fetch_cached_job_result(self, job_hash:str):
         p = self._get_cache_file_path(job_hash=job_hash, create_dir_if_needed=False)
         if not os.path.exists(p):
             return None
@@ -147,12 +124,23 @@ class DiskJobCache:
             with open(p, 'r') as f:
                 return json.load(f)
 
-    def _get_cache_file_path(self, job_hash, create_dir_if_needed):
+    def _get_cache_file_path(self, job_hash:str, create_dir_if_needed:bool):
         dirpath = f'{self._path}/{job_hash[0]}{job_hash[1]}/{job_hash[2]}{job_hash[3]}/{job_hash[4]}{job_hash[5]}'
         if create_dir_if_needed:
             if not os.path.exists(dirpath):
                 os.makedirs(dirpath)
         return f'{dirpath}/{job_hash}.json'
+
+class DatabaseJobCache:
+    def __init__(self, db):
+        self._database = db
+
+    def _cache_job_result(self, job_hash:str, job:Job):
+        self._database._cache_job_result(job_hash, job)
+
+    def _fetch_cached_job_result(self, job_hash:str):
+        return self._database._fetch_cached_job_result(job_hash)
+
 
 
         

--- a/hither/paralleljobhandler.py
+++ b/hither/paralleljobhandler.py
@@ -15,6 +15,7 @@ from ._exceptions import JobCancelledException
 
 class ParallelJobHandler(BaseJobHandler):
     def __init__(self, num_workers):
+        super().__init__()
         self.is_remote = False
         self._num_workers = num_workers
         self._processes: List[dict] = []

--- a/hither/remotejobhandler.py
+++ b/hither/remotejobhandler.py
@@ -13,6 +13,7 @@ from .computeresource import HITHER_COMPUTE_RESOURCE_TO_REMOTE_JOB_HANDLER, HITH
 
 class RemoteJobHandler(BaseJobHandler):
     def __init__(self, *, event_stream_client, compute_resource_id):
+        super().__init__()
         self.is_remote = True
         
         self._event_stream_Client = event_stream_client

--- a/hither/slurmjobhandler.py
+++ b/hither/slurmjobhandler.py
@@ -46,6 +46,7 @@ class SlurmJobHandler(BaseJobHandler):
         additional_srun_opts : List[str], optional
             A list of additional string options to send to srun (only applies of use_slurm is True), by default []
         """
+        super().__init__()
         if not os.path.exists(working_dir):
             os.mkdir(working_dir)
         handler_dir = os.path.join(working_dir, 'tmp_slurm_job_handler_' + _random_string(8))


### PR DESCRIPTION
This PR has 2 suggested improvements for magland/issue42:

* Putting JobHandler internal counts on the base class
* Simplifying JobCache to provide the same code trace for storage interaction whether using the DB or the on-disk cache

As part of the 2nd point there, I also centralized the code for creating a cached version of a Job to within the Job class, right next to the other serialization code. (As is we had the same code repeated in both the Database-cache and Disk-cache versions.)