### PR TITLE
Add __version__ & show on hither-compute-resource. Fixes #64

### DIFF
--- a/bin/hither-compute-resource
+++ b/bin/hither-compute-resource
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from hither import computeresource
+from hither import computeresource, __version__
 import os
 import json
 import click
@@ -12,6 +12,12 @@ import hither as hi
 @click.group(help="Configure and run a hither compute resource. Start by entering a new directory and running the 'config' command.")
 def cli():
     pass
+
+@click.command(help="Display hither version and exit.")
+def version():
+    click.echo(f"This is hither version {__version__}.")
+    exit()
+
 
 class ComputeResourceConfig:
     def __init__(self, config_fname):
@@ -507,11 +513,13 @@ def _append_docker_image_name(x, y):
     else:
         raise Exception(f'Invalid docker image name: {x}')
 
+
 cli.add_command(config)
 cli.add_command(start)
 cli.add_command(start_kachery_server)
 cli.add_command(start_event_stream_server)
 cli.add_command(run_docker_container)
+cli.add_command(version)
 
 if __name__ == "__main__":
     cli()

--- a/hither/__init__.py
+++ b/hither/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.1.5"
+
 from .core import function, container, additional_files, local_modules, opts
 from .core import Config
 from .core import wait

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,26 @@
+import codecs
+import os.path
 import setuptools
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 
 pkg_name = "hither"
 
 setuptools.setup(
     name=pkg_name,
-    version="0.1.3",
+    version=get_version("hither/__init__.py"),
     author="Jeremy Magland",
     author_email="jmagland@flatironinstitute.org",
     description="Run batches of Python functions in containers and on remote servers",
@@ -19,9 +35,9 @@ setuptools.setup(
         "inquirer"
         # non-explicit dependencies: kachery, numpy
     ],
-    classifiers=(
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-    )
+    ]
 )


### PR DESCRIPTION
Added `__version__` to `__init__.py` and added code from [python documentation](https://packaging.python.org/guides/single-sourcing-package-version/) to incorporate that version string into `setup.py` by reference. Added new `click` command to `hither-compute-resource` to print the single-sourced package version via import.

There are many different ways to accomplish these tasks; I don't claim this is the most modern or "correct" way, but confirmed it worked in local testing using `pip install ./hither` from my `src` (github root) directory.