### PR TITLE
make kachery a dependency of hither in setup.py. Fixes #72

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setuptools.setup(
     install_requires=[
         "pymongo",
         "click",
-        "inquirer"
-        # non-explicit dependencies: kachery, numpy
+        "inquirer",
+        "kachery>=0.5.0"
+        # non-explicit dependencies: numpy
     ],
     classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Added `kachery>=0.5.0` (the current version I had installed) to `setup.py`.

`pip uninstall kachery` to remove dependency, then confirmed that `pip install ./hither` to install local version also installed kachery.