### PR TITLE
suppress the "Cannot kill container" messages

### DIFF
--- a/hither/_run_serialized_job_in_container.py
+++ b/hither/_run_serialized_job_in_container.py
@@ -259,7 +259,7 @@ def _run_serialized_job_in_container(job_serialized, cancel_filepath: Union[str,
                 #!/bin/bash
 
                 docker stop {docker_container_name} || true
-                docker kill {docker_container_name} || true
+                docker kill {docker_container_name} 2>&1 | grep -v 'is not running' || true
                 docker rm {docker_container_name} || true
                 """)
                 ss_cleanup.start()

--- a/hither/_shellscript.py
+++ b/hither/_shellscript.py
@@ -138,7 +138,7 @@ class ShellScript():
                     pass
     
     def _send_docker_signal(self, sig_str):
-        cmd = f'docker kill {self._docker_container_name} -s {sig_str}'
+        cmd = f"docker kill {self._docker_container_name} -s {sig_str} 2>&1 | grep -v 'is not running'"
         print(cmd)
         os.system(cmd)
 


### PR DESCRIPTION
Fixes #78
This is quite hacky, because it requires redirecting STDERR to STDOUT (so someone attempting to consume STDERR will find no signal, and will have to look at STDOUT for it; and STDOUT will be polluted with any other errors). I've implemented it in `_run_serialized_job_in_container` and in `_shellscript.py:_send_docker_signal()` which is also capable of generating this message; but there could potentially be other places where `docker kill` is called and we'd need to catch all of them.

Longer-term, we should probably come up with a better solution for this. Maybe something like [the Docker SDK for Python](https://docker-py.readthedocs.io/en/stable/) could help formalize the way we interact with the docker daemon, and avoid shelling out to bash commands so much, which would sidestep the problem entirely.