### PR TITLE
Document how hither functions handle numpy arrays.

### DIFF
--- a/doc/containerization.md
+++ b/doc/containerization.md
@@ -40,3 +40,21 @@ The `image_url` can refer to an image on a public hosting solution such as
 DockerHub, or to any other location which can be accessed by the system which will be running hither.
 
 The second argument to `@hi.function` is the version of the function, which is relevant to the optional [job cache](./job-cache.md).
+
+## Job Serialization
+
+In the context of computing, [serialization](https://en.wikipedia.org/wiki/Serialization) means converting
+data into a format that can be stored or transmitted between processes and machines, and then later
+reconstructed. In order for a hither function to run in a container, the Job (that is, the function code,
+with its specific inputs) must be serialized. hither converts function code (in text format) and
+basic [data types](https://docs.python.org/3/library/stdtypes.html) to
+[JSON](https://www.json.org/json-en.html).
+
+However, the JSON format is not necessarily appropriate for large files or complex objects
+such as [numpy arrays](https://numpy.org/doc/1.18/reference/generated/numpy.array.html). Numpy
+arrays are written out to files on the file system. The corresponding file is then stored
+in kachery, hither's universal content manager, and the file contents are retrieved when the
+Job is deserialized and run in a container.
+
+Functions that take input objects with non-serializable types are not currently supported
+by hither.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -656,6 +656,21 @@ A WHILE. IS THIS CORRECT?__
 Large numpy arrays are serialized to the filesystem and stored in
 kachery when they would otherwise need to be shipped over the network. 
 
+When hither runs a Job on a remote compute resource, it first
+[converts the job to a format that can be transmitted over a network
+connection](./containerization.md#job-serialization). As part of this process,
+numpy arrays are written to file and stored in kachery.
+
+Similarly, whenever a Job object is created, any numpy-array-typed inputs
+are stored in kachery. And, any numpy-type object in the results of a
+hither function will be stored in kachery by default if the function is
+run outside of a container.
+
+__QUESTION: I think the above is actually just a long-winded way of saying
+"this always happens," because the cases I've enumerated are 1) results,
+when run locally; 2) results, when run in container; and 3) parameters, always.
+Is this correct? Does anything else need to be said about this?__
+
 ### What is a hither `File` object?
 
 A `File` object in hither represents a regular file that has been stored in the


### PR DESCRIPTION
Fixes #77
I made some quick notes about serialization (in the containers document) and somewhat expanded the question in the FAQ on numpy arrays. I'm not sure if more needs to be said here--there probably isn't enough for a whole separate document.

Also please note the question I had about my edit in the FAQ; am I wrong to say that this behavior always happens? If I'm right, can we just sidestep my wading into the details on it?