### PR TITLE
tweak to deployed package test

### DIFF
--- a/devel/test_deployed/build_and_run_test.sh
+++ b/devel/test_deployed/build_and_run_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 docker build -t hither_test_deployed .
 


### PR DESCRIPTION
There was a problem: if the build failed, the test still continued. So I added `set -ex` at the top of the bash script.